### PR TITLE
feat: Test CommentRepository

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/comment/dto/CommentDTO.java
+++ b/src/main/java/com/kakao/saramaracommunity/comment/dto/CommentDTO.java
@@ -1,0 +1,31 @@
+package com.kakao.saramaracommunity.comment.dto;
+
+import jakarta.persistence.Column;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentDTO {
+
+    private Long commentId;
+
+    private Long boardId;
+
+    private Long memberId;
+
+    private String content;
+
+    private Long likes;
+
+    private Long pick;
+
+    private LocalDateTime regDate;
+
+    private LocalDateTime modDate;
+}

--- a/src/main/java/com/kakao/saramaracommunity/comment/entity/Comment.java
+++ b/src/main/java/com/kakao/saramaracommunity/comment/entity/Comment.java
@@ -32,19 +32,30 @@ public class Comment extends BaseTimeEntity {
 
     @Lob
     @Column(nullable = false)
-    private String text;
+    private String content;
 
     @ColumnDefault("0")
     private Long likes;
 
-    private Integer pick;
+    private Long pick;
 
     @Builder
-    public Comment(Board board, Member member, String text, Long likes, Integer pick) {
+    public Comment(Board board, Member member, String content, Long likes, Long pick) {
         this.board = board;
         this.member = member;
-        this.text = text;
+        this.content = content;
         this.likes = likes;
         this.pick = pick;
+    }
+
+    // 수정을 위한 메서드. 내용과 사진 픽 숫자를 바꿔주게 된다.
+    public void change(String content, Long pick){
+        this.content = content;
+        this.pick = pick;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.likes = this.likes == null ? 0 : this.likes;
     }
 }

--- a/src/main/java/com/kakao/saramaracommunity/comment/repository/CommentRepository.java
+++ b/src/main/java/com/kakao/saramaracommunity/comment/repository/CommentRepository.java
@@ -4,4 +4,5 @@ import com.kakao.saramaracommunity.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
 }

--- a/src/test/java/com/kakao/saramaracommunity/board/comment/CommentRepositoryTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/board/comment/CommentRepositoryTest.java
@@ -33,16 +33,50 @@ public class CommentRepositoryTest {
         // given
 
         commentRepository.save(Comment.builder()
-                        .text("Test Text")
-                        .pick(0)
+                        .content("Test Text")
+                        .pick(0L)
                         .build());
 
         // when
         List<Comment> commentList = commentRepository.findAll();
 
         // then
-        Comment comment = commentList.get(0);
+        Comment comment = commentList.get(1);
         System.out.println(comment);
-        Assertions.assertThat(comment.getCommentId()).isEqualTo(1L);
+        Assertions.assertThat(comment.getCommentId()).isEqualTo(2L);
+    }
+
+    @Test
+    public void 댓글_수정() {
+        // given
+        Long cno = 1L;
+
+        Optional<Comment> result = commentRepository.findById(cno);
+
+        Comment comment = result.orElseThrow();
+
+        // when
+
+        comment.change("Update content", 2L);
+        commentRepository.save(comment);
+        // then
+
+        System.out.println(commentRepository.findById(1L));
+    }
+
+    @Test
+    public void 댓글_삭제() {
+        Long cno = 1L;
+        commentRepository.deleteById(cno);
+    }
+
+    @Test
+    public void 댓글_찾기() {
+        Long cno = 2L;
+
+        Optional<Comment> findingComment = commentRepository.findById(cno);
+        Comment result = findingComment.orElseThrow();
+
+        System.out.println("result = " + result);
     }
 }


### PR DESCRIPTION
- **댓글 1개 기준으로 CRUD 작성**


- **likes의 초기값으로 0을 넣기위해 @prePersist 활용**
``` java
@ColumnDefault("0")
    private Long likes;
```
위 처럼 `@ColumnDefault("0")` 을 사용해도 DataBase 에는 0이 삽입되지 않고, Null 값이 생기는 문제가 발생하였습니다.
그래서 `@PrePersist` 를 사용하여 sql 로직이 실행될 때 먼저 처리할 수 있는 메서드를 작성하여 `likes` 변수의 값이 지정되지 않으면 0을 삽입하여, 댓글 생성 시 `likes` 를 0으로 바꿔줄 수 있도록 처리하였습니다.

- **댓글의 내용과 사진 픽만 바꿔야되기에 Entity 내에 change 메서드 작성**

- **관련 레퍼런스**
[jpa insert 시 default 값 적용](https://dotoridev.tistory.com/6)