### PR TITLE
feat: Member register api develop apply [service, dto, test]

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/member/dto/MemberSaveRequestDto.java
+++ b/src/main/java/com/kakao/saramaracommunity/member/dto/MemberSaveRequestDto.java
@@ -1,0 +1,40 @@
+package com.kakao.saramaracommunity.member.dto;
+
+import com.kakao.saramaracommunity.member.entity.Member;
+import com.kakao.saramaracommunity.member.entity.Role;
+import com.kakao.saramaracommunity.member.entity.Type;
+import lombok.*;
+
+
+@NoArgsConstructor
+@ToString
+@Getter
+public class MemberSaveRequestDto {
+    private Type type;
+    private String email;
+    private String nickname;
+    private String password;
+    private Role role;
+    private String picture;
+
+    @Builder
+    public MemberSaveRequestDto(Type type, String email, String nickname, String password, Role role, String picture) {
+        this.type = type;
+        this.email = email;
+        this.nickname = nickname;
+        this.password = password;
+        this.role = role;
+        this.picture = picture;
+    }
+
+    public Member toEntity() {
+        return Member.builder()
+                .type(type)
+                .email(email)
+                .nickname(nickname)
+                .password(password)
+                .role(role)
+                .picture(picture)
+                .build();
+    }
+}

--- a/src/main/java/com/kakao/saramaracommunity/member/dto/OAuthResponseDto.java
+++ b/src/main/java/com/kakao/saramaracommunity/member/dto/OAuthResponseDto.java
@@ -3,7 +3,7 @@ package com.kakao.saramaracommunity.member.dto;
 import lombok.Getter;
 
 @Getter
-public class OAuthResponseDTO {
+public class OAuthResponseDto {
     private String accessToken;
     private String tokenType = "Bearer";
 }

--- a/src/main/java/com/kakao/saramaracommunity/member/entity/Member.java
+++ b/src/main/java/com/kakao/saramaracommunity/member/entity/Member.java
@@ -40,8 +40,9 @@ public class Member extends BaseTimeEntity {
     private String token;
 
     @Builder
-    public Member(Type type, String email, String nickname, String password, Role role, String picture) {
+    public Member(Type type, Long memberId, String email, String nickname, String password, Role role, String picture) {
         this.type = type;
+        this.memberId = memberId;
         this.email = email;
         this.nickname = nickname;
         this.password = password;

--- a/src/main/java/com/kakao/saramaracommunity/member/entity/Member.java
+++ b/src/main/java/com/kakao/saramaracommunity/member/entity/Member.java
@@ -21,15 +21,14 @@ public class Member extends BaseTimeEntity {
     private Long memberId;
 
     @Enumerated(EnumType.STRING)
-//    @Column(nullable = false)
     private Type type;
+
     @Column(nullable = false, length = 100)
     private String email;
 
     @Column(nullable = false, length = 50)
     private String nickname;
 
-//    @Column(nullable = false)
     private String password;
 
     @Enumerated(EnumType.STRING)
@@ -59,5 +58,12 @@ public class Member extends BaseTimeEntity {
 
     public String getRoleKey() {
         return this.role.getKey();
+    }
+
+    public void changePassword(String password) {
+        this.password = password;
+    }
+    public void changeEmail(String email) {
+        this.email = email;
     }
 }

--- a/src/main/java/com/kakao/saramaracommunity/member/service/MemberSerivce.java
+++ b/src/main/java/com/kakao/saramaracommunity/member/service/MemberSerivce.java
@@ -1,0 +1,7 @@
+package com.kakao.saramaracommunity.member.service;
+
+import com.kakao.saramaracommunity.member.dto.MemberSaveRequestDto;
+
+public interface MemberSerivce {
+    Long register(MemberSaveRequestDto requestDto);
+}

--- a/src/main/java/com/kakao/saramaracommunity/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/member/service/MemberServiceImpl.java
@@ -1,0 +1,19 @@
+package com.kakao.saramaracommunity.member.service;
+
+import com.kakao.saramaracommunity.member.dto.MemberSaveRequestDto;
+import com.kakao.saramaracommunity.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@RequiredArgsConstructor
+@Service
+public class MemberServiceImpl implements MemberSerivce {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public Long register(MemberSaveRequestDto requestDto){
+        return memberRepository.save(requestDto.toEntity()).getMemberId();
+    }
+}

--- a/src/test/java/com/kakao/saramaracommunity/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/member/service/MemberServiceTest.java
@@ -1,0 +1,44 @@
+package com.kakao.saramaracommunity.member.service;
+
+import com.kakao.saramaracommunity.member.dto.MemberSaveRequestDto;
+import com.kakao.saramaracommunity.member.entity.Member;
+import com.kakao.saramaracommunity.member.entity.Role;
+import com.kakao.saramaracommunity.member.entity.Type;
+import com.kakao.saramaracommunity.member.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+public class MemberServiceTest {
+
+    @Autowired
+    private MemberSerivce memberSerivce;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    public void 사용자_회원가입() throws Exception {
+        // given
+        MemberSaveRequestDto memberRegisterDTO = MemberSaveRequestDto.builder()
+                .type(Type.LOCAL)
+                .nickname("lango")
+                .email("lango@kakao.com")
+                .password("test123")
+                .role(Role.USER)
+                .picture("test")
+                .build();
+        Long newMemberId = memberSerivce.register(memberRegisterDTO);
+
+        // when
+        Optional<Member> member = memberRepository.findById(newMemberId);
+
+        // then
+        assertThat(member.get().getEmail()).isEqualTo("lango@kakao.com");
+    }
+}


### PR DESCRIPTION
## Motivation
- 사용자 회원가입 서비스 로직 기능을 추가하였습니다.
- 회원가입과 관련된 service, serviceImpl, test 코드를 추가하였습니다.
- @hb9397 signup 메소드가 이미 구현되어 있음에도 회원가입을 구현한 이유는 **문서화 도구인 Spring REST Docs를 적용**하기 위함입니다.

## Key Changes
- DTO 객체를 비즈니스 별로 두려고 하여 MemberDto가 아닌 MemberSaveRequestDto 등으로 기능 별 요청/응답별로 DTO를 구성하였습니다. 이후 기능 확장에 따라 기능의 요청/응답별로 DTO를 추가하면 됩니다.
- Member의 경우는 Board와 달리 연관 관계가 포함되어 있지 않기 때문에 DTO와 Entity 사이의 변환 로직에서 기본 키를 포함할 필요가 없다고 판단하여 로직을 구상하였으니 이를 위주로 코드를 참고하셨으면 합니다.
- 생각해보니 DTO 클래스들을 `xxxDTO` 등으로 카멜 케이스에 위반하여 명명하였음을 확인하여 member 패키지의 DTO 클래스들을 `xxxDto` 등으로 변경하였으니 확인 바랍니다.
- Member Entity 클래스의 type과 password 필드에 선언된 `@Column(nullable = false)`을 주석으로 올린 이유는 OAuth2(소셜로그인)과 관련된 테스트가 진행중이기에 참고를 부탁 드립니다.

## To Reviewers
- MemberServiceTest의 테스트를 통해 사용자 회원가입 여부를 확인해주시면 됩니다.