### PR TITLE
:sparkles: feat: ModelMapper Confing file 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// modelmapper
+	implementation group: 'org.modelmapper', name: 'modelmapper', version: '3.1.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kakao/saramaracommunity/config/MapperConfig.java
+++ b/src/main/java/com/kakao/saramaracommunity/config/MapperConfig.java
@@ -1,0 +1,33 @@
+package com.kakao.saramaracommunity.config;
+
+import lombok.extern.log4j.Log4j2;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MapperConfig {
+
+    /**
+     * Object Converter (객체 변환)을 위한 ModelMapper 설정 Bean 메서드입니다.
+     * Mapper 객체에 설정 정보가 필요하므로 new 연산을 이용해 mapper 객체 생성 후, 설정 정보를 담는 식으로 진행했습니다.
+     *
+     * setFieldMatchingEnabled() : 필드 매칭 활성화 메서드입니다. 필드 네이밍을 통해 converter 여부를 판단합니다.
+     * setFieldAccessLevel() : 필드 접근 수준 설정 메서드입니다. 현 프로젝트 개발 기준 private 필드 변수 접근을 위해 메서드 파라미터를 PRVIATE도 접근 가능하게 설정했습니다.
+     * setMethodAccessLevel() : 메서드 접근 수준 설정 메서드입니다. 동작 원리는 위와 동일합니다.
+     * setMatchingStrategy() : 필드 이름을 확인하고 매핑을 해주는 설정 메서드입니다. 현재는 LOOSE이기에 유사하다면 매핑을 해줍니다.
+     */
+    @Bean
+    public ModelMapper getMapper() {
+        ModelMapper modelMapper = new ModelMapper();
+        modelMapper.getConfiguration() // 이전 생성한 ModelMapper 참조
+                .setFieldMatchingEnabled(true) // 필드 매칭 활성화
+                .setSkipNullEnabled(true)
+                .setFieldAccessLevel(
+                        org.modelmapper.config.Configuration.AccessLevel.PRIVATE) // 필드 접근 수준을 PRIVATE수준도 가능하게끔 변경
+                .setMethodAccessLevel(org.modelmapper.config.Configuration.AccessLevel.PRIVATE)
+                .setMatchingStrategy(MatchingStrategies.LOOSE); // 필드 이름이 정확히 일치하지 않더라도 유사한 이름이면 매핑해줌
+        return modelMapper;
+    }
+}


### PR DESCRIPTION
## 🤔 Motivation
- 객체 변환기(ModelMapper) 에 대한 Config file을 작성하였습니다.

<br>

## 💡 Key Changes
- 사용방법은 여러가지가 있을테지만 대표적으로 VO와 DTO 변환을 위해 편리하게 사용됩니다.
``` java
private final MemberRepository memberRepository;

    private final ModelMapper modelMapper;

    // 회원가입 메서드
    @Override
    public Long register(MemberDTO memberDTO) {
        Member member = modelMapper.map(memberDTO, Member.class);
        Long mid = memberRepository.save(member).getMid();

        return mid;
    }
```
위는 modelMapper 사용법에 예제입니다.
`modelMapper` Bean을 주입받아 `map()`을 사용하여 객체 변환을 합니다.
`map(변화를 시킬 객체, 바꾸려는 타입)` 을 이용해 사용하면 될만큼 간편합니다.

💡 허나 타입변환이 자동으로 일어날만큼 성능오버헤드가 일어날 수 있으므로 필드나 메서드의 갯수가 많아질수록 사용에 주의를 해야됩니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
-
