### PR TITLE
[Feat/게시글작성] 게시글 첨부 이미지 파일 등록하기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,4 @@ $RECYCLE.BIN/
 application-local.yml
 application-dev.yml
 application-prod.yml
+application-test.yml

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,13 @@ dependencies {
 
 	// modelmapper
 	implementation group: 'org.modelmapper', name: 'modelmapper', version: '3.1.1'
+
+	// amazon s3
+	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.3.1'
+
+	// amazon s3 test
+	testImplementation 'io.findify:s3mock_2.12:0.2.4'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kakao/saramaracommunity/attach/controller/AttachController.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/controller/AttachController.java
@@ -1,0 +1,41 @@
+package com.kakao.saramaracommunity.attach.controller;
+
+import com.kakao.saramaracommunity.attach.dto.request.AttachRequest;
+import com.kakao.saramaracommunity.attach.dto.response.AttachResponse;
+import com.kakao.saramaracommunity.attach.service.AttachService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * AttachController: 이미지 업로드 관련 요청을 받을 컨트롤러 클래스
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/attach")
+public class AttachController {
+
+    private final AttachService attachService;
+
+    /**
+     * uploadImage: 이미지 업로드 API
+     * URL: /api/v1/attach/upload
+     * 1장 이상, 최대 5장까지의 이미지를 S3와 MariaDB에 업로드한다.
+     *
+     * @param request type, id, imgList
+     * @return AttachResponse
+     */
+    @PostMapping("/upload")
+    public ResponseEntity<AttachResponse> uploadImage(@Valid AttachRequest.UploadRequest request) {
+        AttachResponse response = attachService.uploadImage(request);
+        return ResponseEntity.ok().body(response);
+    }
+
+}

--- a/src/main/java/com/kakao/saramaracommunity/attach/dto/request/AttachRequest.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/dto/request/AttachRequest.java
@@ -1,0 +1,46 @@
+package com.kakao.saramaracommunity.attach.dto.request;
+
+import com.kakao.saramaracommunity.attach.entity.AttachType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
+
+/**
+ * AttachRequest: Attach(첨부 이미지) 관련 요청 DTO를 관리하는 클래스
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+@Getter
+public class AttachRequest {
+
+    /**
+     * UploadRequest: uploadImage 메서드의 요청 데이터를 담을 DTO 클래스
+     * type: 게시글 및 댓글 유형 여부
+     * id: 게시글이나 댓글의 번호(PK)
+     * imgList: 이미지의 순서(Long)와 이미지 파일(MultipartFile)이 담긴 Map
+     */
+    @Getter
+    public static class UploadRequest {
+
+        @NotNull(message = "어떤 유형의 글에서 이미지가 등록되었는지 알 수 없습니다.")
+        private AttachType type;
+
+        @NotNull(message = "게시글이나 댓글의 번호값을 알 수 없습니다.")
+        private Long id;
+
+        private Map<Long, MultipartFile> imgList;
+
+        @Builder
+        public UploadRequest(AttachType type, Long id, Map<Long, MultipartFile> imgList) {
+            this.type = type;
+            this.id = id;
+            this.imgList = imgList;
+        }
+
+    }
+
+}

--- a/src/main/java/com/kakao/saramaracommunity/attach/dto/response/AttachResponse.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/dto/response/AttachResponse.java
@@ -1,0 +1,26 @@
+package com.kakao.saramaracommunity.attach.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * AttachResponse: uploadImage 메서드의 응답 데이터를 담을 DTO 클래스
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+@Getter
+public class AttachResponse {
+
+    private String code;
+    private String msg;
+    private boolean data;
+
+    @Builder
+    public AttachResponse(String code, String msg, boolean data) {
+        this.code = code;
+        this.msg = msg;
+        this.data = data;
+    }
+
+}

--- a/src/main/java/com/kakao/saramaracommunity/attach/entity/Attach.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/entity/Attach.java
@@ -2,18 +2,27 @@ package com.kakao.saramaracommunity.attach.entity;
 
 import com.kakao.saramaracommunity.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
-
-@NoArgsConstructor
-@AllArgsConstructor
-@Where(clause = "deleted_at is NULL")
-@SQLDelete(sql = "update comment set deleted_at = CURRENT_TIMESTAMP where comment_id = ?")
+/**
+ * Attach: 이미지 첨부파일 관리 테이블
+ * attachId: 해당 테이블의 PK 필드
+ * type: AttachType(Board or Comment)을 속성으로 가지는 필드
+ * id: Long형의 Board의 boardId나 Comment의 commentId를 속성으로 가지는 필드
+ * seq: 사용자가 지정한 이미지 순서를 저장할 필드
+ * imgPath: S3 버킷에 등록된 이미지 URL을 저장할 필드
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
 @Getter
+@NoArgsConstructor
+@Where(clause = "deleted_at is NULL")
+@SQLDelete(sql = "update attach set deleted_at = CURRENT_TIMESTAMP where attach_id = ?")
 @Entity
 public class Attach extends BaseTimeEntity {
 
@@ -21,6 +30,24 @@ public class Attach extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long attachId;
 
+    @Enumerated(value = EnumType.STRING)
+    private AttachType type;
+
+    @Column(nullable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long seq;
+
     @Column(nullable = false)
     private String imgPath;
+
+    @Builder
+    public Attach(AttachType type, Long id, Long seq, String imgPath) {
+        this.type = type;
+        this.id = id;
+        this.seq = seq;
+        this.imgPath = imgPath;
+    }
+
 }

--- a/src/main/java/com/kakao/saramaracommunity/attach/entity/AttachType.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/entity/AttachType.java
@@ -1,0 +1,15 @@
+package com.kakao.saramaracommunity.attach.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AttachType {
+
+    BOARD("게시글"),
+    COMMENT("댓글");
+
+    private final String text;
+
+}

--- a/src/main/java/com/kakao/saramaracommunity/attach/repository/AttachRepository.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/repository/AttachRepository.java
@@ -1,0 +1,8 @@
+package com.kakao.saramaracommunity.attach.repository;
+
+import com.kakao.saramaracommunity.attach.entity.Attach;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AttachRepository extends JpaRepository<Attach, Long> {
+
+}

--- a/src/main/java/com/kakao/saramaracommunity/attach/service/AttachService.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/service/AttachService.java
@@ -1,0 +1,17 @@
+package com.kakao.saramaracommunity.attach.service;
+
+
+import com.kakao.saramaracommunity.attach.dto.request.AttachRequest;
+import com.kakao.saramaracommunity.attach.dto.response.AttachResponse;
+
+/**
+ * AttachService: 이미지 첨부파일 관련 비즈니스 로직을 수행할 서비스 인터페이스
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+public interface AttachService {
+
+    AttachResponse uploadImage(AttachRequest.UploadRequest request);
+
+}

--- a/src/main/java/com/kakao/saramaracommunity/attach/service/AttachServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/service/AttachServiceImpl.java
@@ -1,0 +1,95 @@
+package com.kakao.saramaracommunity.attach.service;
+
+import com.kakao.saramaracommunity.attach.dto.request.AttachRequest;
+import com.kakao.saramaracommunity.attach.dto.response.AttachResponse;
+import com.kakao.saramaracommunity.attach.entity.Attach;
+import com.kakao.saramaracommunity.attach.entity.AttachType;
+import com.kakao.saramaracommunity.attach.repository.AttachRepository;
+import com.kakao.saramaracommunity.util.AwsS3Uploader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AttachServiceImpl: 이미지 첨부파일 관련 비즈니스 로직을 수행할 AttachService 서비스 인터페이스의 구현체 클래스
+ *
+ * 비즈니스 로직 내부에서 전역 예외 처리에 대한 부분과 로그 출력이 미흡한 상태입니다.
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+@Log4j2
+@RequiredArgsConstructor
+@Service
+public class AttachServiceImpl implements AttachService {
+
+    private final AttachRepository attachRepository;
+
+    private final AwsS3Uploader awsS3Uploader;
+
+    /**
+     * uploadMultipleImage: 1장 이상의 이미지를 S3 버킷에 업로드 한후, ATTACH 테이블에 저장하는 메서드
+     * request의 이미지 순서와 파일이 담긴 Map을 파싱하여 List에 담은 후 ATTACH 테이블에 삽입
+     *
+     * @param request type, id, imgList
+     * @return AttachResponse
+     */
+    @Override
+    public AttachResponse uploadImage(AttachRequest.UploadRequest request) {
+        try {
+
+            AttachType type = request.getType();
+            Long id = request.getId();
+            Map<Long, MultipartFile> imgList = request.getImgList();
+            List<Attach> attachs = new ArrayList<>();
+
+            if(imgList.size() < 1 || imgList.size() > 5) {
+                log.error("이미지는 1장 이상, 최대 5장까지 등록할 수 있습니다.");
+                return AttachResponse.builder()
+                        .code(String.valueOf(HttpStatus.OK))
+                        .msg("이미지는 1장 이상, 최대 5장까지 등록할 수 있습니다.")
+                        .data(false)
+                        .build();
+            }
+
+            for (long key : imgList.keySet()) {
+                log.info("[AttachServiceImpl] 업로드할 이미지 정보 - 이미지순서: {}, 이미지파일: {}", key, imgList.get(key));
+                String imgPath = awsS3Uploader.upload(imgList.get(key));
+                if (imgPath != null) {
+                    Attach attach = Attach.builder()
+                            .type(type)
+                            .id(id)
+                            .seq(key)
+                            .imgPath(imgPath)
+                            .build();
+                    attachs.add(attach);
+                }
+            }
+
+            log.info("[AttachServiceImpl] S3 버킷 업로드 완료 후, DB에 URL을 저장합니다.");
+            attachRepository.saveAll(attachs);
+
+            return AttachResponse.builder()
+                    .code(String.valueOf(HttpStatus.OK))
+                    .msg("정상적으로 이미지 업로드를 완료했습니다.")
+                    .data(true)
+                    .build();
+
+        } catch (Exception e) {
+            log.error("error: ", e);
+            return AttachResponse.builder()
+                    .code(String.valueOf(HttpStatus.OK))
+                    .msg("이미지를 업로드하던 중 문제가 발생했습니다.")
+                    .data(false)
+                    .build();
+        }
+
+    }
+
+}

--- a/src/main/java/com/kakao/saramaracommunity/config/AwsS3Config.java
+++ b/src/main/java/com/kakao/saramaracommunity/config/AwsS3Config.java
@@ -1,0 +1,41 @@
+package com.kakao.saramaracommunity.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * AwsS3Config: AWS S3 버킷과 관련된 설정 클래스
+ * 테스트 환경에서는 적용되지 않도록 @Profile 어노테이션을 구성했습니다.
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+@Profile("!test")
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .withRegion(region)
+                .build();
+    }
+
+}

--- a/src/main/java/com/kakao/saramaracommunity/config/SecurityConfig.java
+++ b/src/main/java/com/kakao/saramaracommunity/config/SecurityConfig.java
@@ -76,7 +76,7 @@ public class SecurityConfig {
         httpSecurity
                 .authorizeHttpRequests()
                 .requestMatchers( "/favicon.ico","/error", "/api/authenticate","/api/signup", "/api/login").permitAll()
-                .requestMatchers("/auth/**", "/oauth2/**", "/api/v1/board/**", "/api/v1/comment/**").permitAll()
+                .requestMatchers("/auth/**", "/oauth2/**", "/api/v1/board/**", "/api/v1/comment/**", "/api/v1/attach/**").permitAll()
                 .anyRequest().authenticated();
 
         httpSecurity.addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/kakao/saramaracommunity/util/AwsS3Uploader.java
+++ b/src/main/java/com/kakao/saramaracommunity/util/AwsS3Uploader.java
@@ -1,0 +1,74 @@
+package com.kakao.saramaracommunity.util;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * AwsS3Uploader: AWS S3 버킷에 파일 업로드 로직을 수행할 클래스
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+@Log4j2
+@RequiredArgsConstructor
+@Component
+public class AwsS3Uploader {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String upload(MultipartFile file) throws IOException {
+        boolean result = validateFileExists(file);
+        if(!result) {
+            log.info("[AwsS3Uploader] 업로드할 파일이 존재하지 않습니다.");
+            return null;
+        }
+
+        // 파일 명 생성하기
+        String fileName = FileUtil.buildFileName(file.getOriginalFilename());
+        log.info("[AwsS3Uploader] 업로드할 파일명: {}", fileName);
+
+        // 파일 형식 설정
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(file.getContentType());
+
+        // 파일의 내용을 읽어서 S3에 전송
+        try (InputStream inputStream = file.getInputStream()) {
+            log.info("[AwsS3Uploader] S3 버킷에 파일 업로드를 진행합니다.");
+            amazonS3Client.putObject(new PutObjectRequest(bucketName, fileName, inputStream, objectMetadata).withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            log.info("[AwsS3Uploader] S3 버킷에 파일을 업로드 하던 중 문제가 발생했습니다.");
+            e.printStackTrace();
+            return null;
+        }
+
+        // S3 버킷에 업로드 된 이미지 파일의 실제 URL을 리턴
+        String imagePath = amazonS3Client.getUrl(bucketName, fileName).toString();
+        log.info("[AwsS3Uploader] S3 파일 업로드 성공했습니다, imgpath: {}", imagePath);
+
+        return imagePath;
+    }
+
+    /**
+     * validateFileExists: 업로드할 파일의 존재여부를 반환하는 메서드
+     *
+     * @param file
+     * @return boolean
+     */
+    private boolean validateFileExists(MultipartFile file) {
+        return !file.isEmpty();
+    }
+
+}

--- a/src/main/java/com/kakao/saramaracommunity/util/FileUtil.java
+++ b/src/main/java/com/kakao/saramaracommunity/util/FileUtil.java
@@ -1,0 +1,27 @@
+package com.kakao.saramaracommunity.util;
+
+/**
+ * FileUtil: 파일의 originalFileName(원본이름)을 인자로 받아 파일명을 새로 지어주는 클래스
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+public class FileUtil {
+
+    private static final String FILE_EXTENSION_SEPARATOR = ".";
+
+    private static final String CATEGORY_PREFIX = "/";
+
+    private static final String TIME_SEPARATOR = "_";
+
+    private static final int UNDER_BAR_INDEX = 1;
+
+    public static String buildFileName(String originalFileName) {
+        int fileExtensionIndex = originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR);
+        String fileExtension = originalFileName.substring(fileExtensionIndex);
+        String fileName = originalFileName.substring(0, fileExtensionIndex);
+        String now = String.valueOf(System.currentTimeMillis());
+        return CATEGORY_PREFIX + fileName + TIME_SEPARATOR + now + fileExtension;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
       local: local
       dev: dev
       prod: prod
+      test: test
 logging:
   level:
     org.hibernate.type.descriptor.sql: trace

--- a/src/test/java/com/kakao/saramaracommunity/attach/AwsS3/AwsS3Test.java
+++ b/src/test/java/com/kakao/saramaracommunity/attach/AwsS3/AwsS3Test.java
@@ -1,0 +1,77 @@
+package com.kakao.saramaracommunity.attach.AwsS3;
+
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.kakao.saramaracommunity.config.AwsS3MockConfig;
+import io.findify.s3mock.S3Mock;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.util.FileCopyUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * AwsS3Test: S3 버킷과 연동하여 이미지 객체 업로드 여부를 테스트할 클래스
+ *
+ * 아직 단위 테스트와 통합 테스트 구분이 명확하지 않은 상태입니다.
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+@Import(AwsS3MockConfig.class)
+@ActiveProfiles("test")
+@SpringBootTest
+public class AwsS3Test {
+
+    @Autowired
+    private AmazonS3 amazonS3;
+
+    @Autowired
+    private static final String BUCKET_NAME = "test";
+
+    @BeforeAll
+    static void setUp(@Autowired S3Mock s3Mock, @Autowired AmazonS3 amazonS3) {
+        s3Mock.start();
+        amazonS3.createBucket(BUCKET_NAME);
+    }
+
+    @AfterAll
+    static void tearDown(@Autowired S3Mock s3Mock, @Autowired AmazonS3 amazonS3) {
+        amazonS3.shutdown();
+        s3Mock.stop();
+    }
+
+    @DisplayName("AWS S3 버킷에 이미지 파일을 업로드한다.")
+    @Test
+    void test() throws IOException {
+        // given
+        String path = "test.png";
+        String contentType = "image/png";
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(contentType);
+        PutObjectRequest putObjectRequest = new PutObjectRequest(BUCKET_NAME, path, new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)), objectMetadata);
+        amazonS3.putObject(putObjectRequest);
+
+        // when
+        S3Object s3Object = amazonS3.getObject(BUCKET_NAME, path);
+
+        // then
+        assertThat(s3Object.getKey()).isEqualTo(path);
+        assertThat(s3Object.getObjectMetadata().getContentType()).isEqualTo(contentType);
+        assertThat(new String(FileCopyUtils.copyToByteArray(s3Object.getObjectContent()))).isEqualTo("");
+    }
+
+}

--- a/src/test/java/com/kakao/saramaracommunity/attach/service/AttachServiceImplTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/attach/service/AttachServiceImplTest.java
@@ -1,0 +1,157 @@
+package com.kakao.saramaracommunity.attach.service;
+
+import com.kakao.saramaracommunity.attach.dto.request.AttachRequest;
+import com.kakao.saramaracommunity.attach.dto.response.AttachResponse;
+import com.kakao.saramaracommunity.attach.entity.AttachType;
+import com.kakao.saramaracommunity.config.AwsS3MockConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.kakao.saramaracommunity.attach.entity.AttachType.BOARD;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+/**
+ * AttachServiceImplTest: 이미지 업로드 서비스 구현체를 테스트할 클래스
+ *
+ * 아직 단위 테스트와 통합 테스트 구분이 명확하지 않은 상태입니다.
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+@SpringBootTest
+class AttachServiceImplTest {
+
+    @Autowired
+    private AttachService attachService;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @DisplayName("1장의 이미지를 업로드하면 S3와 DB에 이미지가 업로드된다.")
+    @Test
+    void singleUploadImage() {
+        // given
+        Map<Long, MultipartFile> imgList = new HashMap<>();
+        MultipartFile file = new MockMultipartFile("file", "test.png", "image/png", "test file".getBytes(StandardCharsets.UTF_8));
+        imgList.put(1L, file);
+
+        AttachRequest.UploadRequest request = AttachRequest.UploadRequest.builder()
+                .type(BOARD)
+                .id(1L)
+                .imgList(imgList)
+                .build();
+
+        // when
+        AttachResponse response = attachService.uploadImage(request);
+
+        // then
+        assertThat(response.getCode()).isEqualTo("200 OK");
+        assertThat(response.isData()).isTrue();
+
+    }
+
+    @DisplayName("여러 장의 이미지를 업로드하면 S3와 DB에 이미지가 업로드된다.")
+    @Test
+    void MultipleUploadImage() {
+        // given
+        Map<Long, MultipartFile> imgList = new HashMap<>();
+        MultipartFile file1 = new MockMultipartFile("file", "test_1.png", "image/png", "test_1 file".getBytes(StandardCharsets.UTF_8));
+        MultipartFile file2 = new MockMultipartFile("file", "test_2.png", "image/png", "test_2 file".getBytes(StandardCharsets.UTF_8));
+        MultipartFile file3 = new MockMultipartFile("file", "test_3.png", "image/png", "test_3 file".getBytes(StandardCharsets.UTF_8));
+        MultipartFile file4 = new MockMultipartFile("file", "test_4.png", "image/png", "test_4 file".getBytes(StandardCharsets.UTF_8));
+        MultipartFile file5 = new MockMultipartFile("file", "test_5.png", "image/png", "test_5 file".getBytes(StandardCharsets.UTF_8));
+        imgList.put(1L, file1);
+        imgList.put(2L, file2);
+        imgList.put(3L, file3);
+        imgList.put(4L, file4);
+        imgList.put(5L, file5);
+
+        AttachRequest.UploadRequest request = AttachRequest.UploadRequest.builder()
+                .type(BOARD)
+                .id(1L)
+                .imgList(imgList)
+                .build();
+
+        // when
+        AttachResponse response = attachService.uploadImage(request);
+
+        // then
+        assertThat(response.getCode()).isEqualTo("200 OK");
+        assertThat(response.isData()).isTrue();
+
+    }
+
+    @DisplayName("이미지는 최소 1장이상 업로드할 수 있다.")
+    @Test
+    void ZeroUploadImage() {
+        // given
+        Map<Long, MultipartFile> imgList = new HashMap<>();
+
+        AttachRequest.UploadRequest request = AttachRequest.UploadRequest.builder()
+                .type(BOARD)
+                .id(1L)
+                .imgList(imgList)
+                .build();
+
+        // when
+        AttachResponse response = attachService.uploadImage(request);
+
+        // then
+        assertThat(response.getCode()).isEqualTo("200 OK");
+        assertThat(response.isData()).isFalse();
+
+    }
+
+    @DisplayName("이미지는 최대 5장까지 업로드할 수 있다.")
+    @Test
+    void MoreThenFiveUploadImage() {
+        // given
+        Map<Long, MultipartFile> imgList = new HashMap<>();
+        MultipartFile file1 = new MockMultipartFile("file", "test_1.png", "image/png", "test_1 file".getBytes(StandardCharsets.UTF_8));
+        MultipartFile file2 = new MockMultipartFile("file", "test_2.png", "image/png", "test_2 file".getBytes(StandardCharsets.UTF_8));
+        MultipartFile file3 = new MockMultipartFile("file", "test_3.png", "image/png", "test_3 file".getBytes(StandardCharsets.UTF_8));
+        MultipartFile file4 = new MockMultipartFile("file", "test_4.png", "image/png", "test_4 file".getBytes(StandardCharsets.UTF_8));
+        MultipartFile file5 = new MockMultipartFile("file", "test_5.png", "image/png", "test_5 file".getBytes(StandardCharsets.UTF_8));
+        MultipartFile file6 = new MockMultipartFile("file", "test_6.png", "image/png", "test_6 file".getBytes(StandardCharsets.UTF_8));
+        imgList.put(1L, file1);
+        imgList.put(2L, file2);
+        imgList.put(3L, file3);
+        imgList.put(4L, file4);
+        imgList.put(5L, file5);
+        imgList.put(6L, file6);
+
+        AttachRequest.UploadRequest request = AttachRequest.UploadRequest.builder()
+                .type(BOARD)
+                .id(1L)
+                .imgList(imgList)
+                .build();
+
+        // when
+        AttachResponse response = attachService.uploadImage(request);
+
+        // then
+        assertThat(response.getCode()).isEqualTo("200 OK");
+        assertThat(response.isData()).isFalse();
+
+    }
+
+}

--- a/src/test/java/com/kakao/saramaracommunity/config/AwsS3MockConfig.java
+++ b/src/test/java/com/kakao/saramaracommunity/config/AwsS3MockConfig.java
@@ -1,0 +1,43 @@
+package com.kakao.saramaracommunity.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import io.findify.s3mock.S3Mock;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * AwsS3MockConfig: AWS S3 버킷 테스트를 위한 설정 클래스
+ * 테스트 환경에서만 동작하도록 @Profile 어노테이션을 구성했습니다.
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+@Profile("test")
+@TestConfiguration
+public class AwsS3MockConfig {
+    @Bean
+    public S3Mock s3Mock() {
+        return new S3Mock.Builder().withPort(8001).withInMemoryBackend().build();
+    }
+    @Primary
+    @Bean(name = "amazonS3", destroyMethod = "shutdown")
+    public AmazonS3Client amazonS3(){
+        AwsClientBuilder.EndpointConfiguration endpoint = new AwsClientBuilder.EndpointConfiguration("http://localhost:8001", Regions.AP_NORTHEAST_2.name());
+        AmazonS3 client = AmazonS3ClientBuilder
+                .standard()
+                .withPathStyleAccessEnabled(true)
+                .withEndpointConfiguration(endpoint)
+                .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+                .build();
+        return (AmazonS3Client) client;
+    }
+
+}


### PR DESCRIPTION
## 🤔 Motivation
-  이미지 업로드 API 개발 - S3 및 MariaDB

<br>

## 💡 Key Changes
- 퍼블릭 S3 버킷에 이미지를 업로드하는 로직을 개발했습니다.
- 앞서, S3 버킷에 이미지 업로드가 완료된 후 해당 이미지 객체의 URL을 MariaDB에 저장하는 로직을 개발했습니다.
- 이미지는 **최소 1장부터, 최대 5장**까지 업로드할 수 있도록 로직을 구현했습니다.
- 이미지가 업로드될 때 1장이든, 5장이든 JPA의 `saveAll()` 메서드를 이용해 DB와의 통신을 1번만 할 수 있도록 구현했습니다.

기능 테스트는 `AttachServiceImplTest` 테스트 클래스 실행하시면 됩니다. 이 때, 테스트를 위해서는 `application-test.yml` 이라는 새로운 설정파일이 필요한데, 노션에 추가하도록 하겠습니다.

> 🥲 기능 개발 자체는 어렵지 않았으나, 데이터 설계와 테스트와 관련한 부분이 기획했던 것과 다르거나 수정되어야 할 부분이 있어 개발일정이 지연된 점  양해 부탁드립니다.

<br>

### 🤔 테스트와 관련하여
현재 이미지를 S3 버킷에 업로드하는 테스트는 **S3Mock** 이라는 외부 라이브러리를 이용하였습니다. 
그리고 전반적인 테스트코드의 스타일은 JUnit5+AssertJ+BDD 형식으로 작성할 예정입니다.

- 단위 테스트와 통합 테스트에 대한 학습이 아직 미흡하여 S3 업로드 및 실제 서비스 메서드와 관련된 테스트 부분이 미흡하게 작성되었습니다.
- 계층간 테스트를 작성하는 방법과 그 안에서 Mocking과 관련된 부분에서 모르거나 덜 학습된 부분이 있어 추후 학습하면서 코드를 개선해나갈 에정입니다.

<br>

### 💬 아쉬운 점
추가로 아직 구조적으로 미흡한 부분은 다음과 같습니다.
1. 테스트: 앞서 말했듯이, 단위테스트 및 통합테스트 작성이 미흡합니다.
2. 요청 및 응답 DTO 구조: 요청과 응답에 사용하는 DTO들의 유효성 검사 로직을 제대로 작성하지 못했습니다.
3. 예외 처리: GlobalExceptionHandler 학습 미흡으로 인해 try/catch문을 사용했습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @byeongJoo05 @hb9397 @IToriginal 

close #25 
