### PR TITLE
[Feat/댓글전체조회, 댓글수정] 하나의 게시글에 대한 모든 댓글 가져오기 ,댓글 수정하기

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/comment/controller/CommentController.java
+++ b/src/main/java/com/kakao/saramaracommunity/comment/controller/CommentController.java
@@ -1,13 +1,12 @@
 package com.kakao.saramaracommunity.comment.controller;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import com.kakao.saramaracommunity.comment.dto.CommentListDTO;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.kakao.saramaracommunity.comment.dto.CommentDTO;
 import com.kakao.saramaracommunity.comment.entity.Comment;
@@ -32,6 +31,17 @@ public class CommentController {
 		Map<String, Object> result = new HashMap<>();
 
 		result.put("result", comment);
+
+		return ResponseEntity.ok(result);
+	}
+
+	@GetMapping("/comments/{boardId}")
+	public ResponseEntity<Map<String, Object>> getBoardComments(@Valid @PathVariable("boardId") Long boardId) {
+		List<CommentListDTO> boardComments = commentService.getBoardComments(boardId);
+
+		Map<String, Object> result = new HashMap<>();
+
+		result.put("result", boardComments);
 
 		return ResponseEntity.ok(result);
 	}

--- a/src/main/java/com/kakao/saramaracommunity/comment/controller/CommentController.java
+++ b/src/main/java/com/kakao/saramaracommunity/comment/controller/CommentController.java
@@ -35,13 +35,26 @@ public class CommentController {
 		return ResponseEntity.ok(result);
 	}
 
-	@GetMapping("/comments/{boardId}")
+	@GetMapping("/{boardId}/comments")
 	public ResponseEntity<Map<String, Object>> getBoardComments(@Valid @PathVariable("boardId") Long boardId) {
 		List<CommentListDTO> boardComments = commentService.getBoardComments(boardId);
 
 		Map<String, Object> result = new HashMap<>();
 
 		result.put("result", boardComments);
+
+		return ResponseEntity.ok(result);
+	}
+
+	@PutMapping("/{commentId}")
+	public ResponseEntity<Map<String, Object>> updateComment(@Valid @PathVariable("commentId") Long commentId,
+															 @Valid @RequestBody CommentDTO commentDTO){
+
+		Boolean updatedComment = commentService.updateComment(commentId, commentDTO);
+
+		Map<String, Object> result = new HashMap<>();
+
+		result.put("result", updatedComment);
 
 		return ResponseEntity.ok(result);
 	}

--- a/src/main/java/com/kakao/saramaracommunity/comment/dto/CommentListDTO.java
+++ b/src/main/java/com/kakao/saramaracommunity/comment/dto/CommentListDTO.java
@@ -1,0 +1,23 @@
+package com.kakao.saramaracommunity.comment.dto;
+
+import lombok.*;
+
+/**
+ * 특정 Board에 대해 댓글을 불러올 때 사용될 DTO입니다.
+ */
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class CommentListDTO {
+
+    private Long commentId;
+
+    private String nickname;
+
+    private String content;
+
+    private Long pick;
+}

--- a/src/main/java/com/kakao/saramaracommunity/comment/entity/Comment.java
+++ b/src/main/java/com/kakao/saramaracommunity/comment/entity/Comment.java
@@ -37,4 +37,16 @@ public class Comment extends BaseTimeEntity {
 
     private Long pick;
 
+
+    /**
+     * 댓글 수정을 위한 메서드입니다.
+     * 전체 수정이 아닌 부분 수정을 위해 내용과 픽만 변경시킬 수 있게 잡아놓았습니다.
+     *
+     * @param content
+     * @param pick
+     */
+    public void changeComment(String content, Long pick) {
+        this.content = content;
+        this.pick = pick;
+    }
 }

--- a/src/main/java/com/kakao/saramaracommunity/comment/repository/CommentRepository.java
+++ b/src/main/java/com/kakao/saramaracommunity/comment/repository/CommentRepository.java
@@ -2,7 +2,18 @@ package com.kakao.saramaracommunity.comment.repository;
 
 import com.kakao.saramaracommunity.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    /**
+     * @param boardId 특정 boardId에 대한 파라미터입니다.
+     * @return
+     * JPQL을 이용하여 boardId 파라미터에 맞는 Comment data들을 추출해옵니다.
+     */
+    @Query("select c from Comment c where c.board.boardId = :boardId")
+    List<Comment> getCommentsByBoard(Long boardId);
 
 }

--- a/src/main/java/com/kakao/saramaracommunity/comment/service/CommentService.java
+++ b/src/main/java/com/kakao/saramaracommunity/comment/service/CommentService.java
@@ -1,11 +1,13 @@
 package com.kakao.saramaracommunity.comment.service;
 
-import com.kakao.saramaracommunity.board.entity.Board;
 import com.kakao.saramaracommunity.comment.dto.CommentDTO;
-import com.kakao.saramaracommunity.comment.entity.Comment;
-import com.kakao.saramaracommunity.member.entity.Member;
+import com.kakao.saramaracommunity.comment.dto.CommentListDTO;
+
+import java.util.List;
 
 public interface CommentService {
 
 	public Long createComment(CommentDTO commentDTO);
+
+	public List<CommentListDTO> getBoardComments(Long BoardId);
 }

--- a/src/main/java/com/kakao/saramaracommunity/comment/service/CommentService.java
+++ b/src/main/java/com/kakao/saramaracommunity/comment/service/CommentService.java
@@ -10,4 +10,6 @@ public interface CommentService {
 	public Long createComment(CommentDTO commentDTO);
 
 	public List<CommentListDTO> getBoardComments(Long BoardId);
+
+	public Boolean updateComment(Long commentId, CommentDTO commentDTO);
 }

--- a/src/main/java/com/kakao/saramaracommunity/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/comment/service/CommentServiceImpl.java
@@ -12,6 +12,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -56,6 +57,28 @@ public class CommentServiceImpl implements CommentService{
                 .map(comment -> modelMapper.map(comment, CommentListDTO.class))
                 .collect(Collectors.toList());
 
+
+        return result;
+    }
+
+    /**
+     * 댓글 수정에 관련된 메서드입니다.
+     * 수정을 위해 VO 클래스에 작성한 changeComment 메서드를 이용하여 부분 수정을 일으킵니다.
+     * Optional 객체를 이용해 안전한 예외처리를 일으킵니다.
+     *
+     * @param commentId 수정할 댓글의 고유 id 입니다.
+     * @param commentDTO 수정할 댓글의 정보입니다.
+     * @return 수정완료되었다는 boolean 값을 던집니다.
+     */
+    @Override
+    public Boolean updateComment(Long commentId, CommentDTO commentDTO) {
+        Optional<Comment> findComment = commentRepository.findById(commentId);
+
+        Comment comment = findComment.orElseThrow();
+
+        comment.changeComment(commentDTO.getContent(), commentDTO.getPick());
+
+        Boolean result = commentRepository.save(comment) != null;
 
         return result;
     }

--- a/src/main/java/com/kakao/saramaracommunity/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/comment/service/CommentServiceImpl.java
@@ -1,6 +1,8 @@
 package com.kakao.saramaracommunity.comment.service;
 
+import com.kakao.saramaracommunity.board.repository.BoardRepository;
 import com.kakao.saramaracommunity.comment.dto.CommentDTO;
+import com.kakao.saramaracommunity.comment.dto.CommentListDTO;
 import com.kakao.saramaracommunity.comment.entity.Comment;
 import com.kakao.saramaracommunity.comment.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +11,9 @@ import lombok.extern.log4j.Log4j2;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @Log4j2
 @RequiredArgsConstructor
@@ -16,8 +21,16 @@ public class CommentServiceImpl implements CommentService{
 
     private final CommentRepository commentRepository;
 
+    private final BoardRepository boardRepository;
+
     private final ModelMapper modelMapper;
 
+    /**
+     * 댓글 생성을 위한 메서드입니다.
+     *
+     * @param commentDTO 생성에 필요한 commentDTO 입니다.
+     * @return 생성된 comment의 고유 id를 반환해줍니다.
+     */
     @Override
     public Long createComment(CommentDTO commentDTO) {
         Comment comment = modelMapper.map(commentDTO, Comment.class);
@@ -25,5 +38,25 @@ public class CommentServiceImpl implements CommentService{
         Long cid = commentRepository.save(comment).getCommentId();
 
         return cid;
+    }
+
+    /**
+     * 특정 보드에 대한 모든 댓글을 가져오는 메서드입니다.
+     * Stream객체를 이용하여 Comment타입 리스트를 불러온 데이터들을 반환타입인 CommentListDTO 형식으로 convert 해줍니다.
+     *
+     * @param boardId 특정 보드에 대한 고유id 파라미터입니다.
+     * @return 해당 보드에 대한 모든 댓글들을 반환해줍니다.
+     */
+    @Override
+    public List<CommentListDTO> getBoardComments(Long boardId) {
+
+        List<Comment> comments = commentRepository.getCommentsByBoard(boardId);
+
+        List<CommentListDTO> result = comments.stream()
+                .map(comment -> modelMapper.map(comment, CommentListDTO.class))
+                .collect(Collectors.toList());
+
+
+        return result;
     }
 }


### PR DESCRIPTION
## 🤔 Motivation
- 하나의 게시글에 대한 모든 댓글 가져오기
- 댓글 수정하기

<br>

## 💡 Key Changes
- [✨ feat: 하나의 게시글에 대한 모든 댓글 가져오기](https://github.com/four-uncles/saramara-community-server/commit/c065b892f4a9e86a334966d0acfcf231cdc1fdc4)
`boardId` 를 기준으로 관련된 모든 댓글을 가져오는 API를 작성하였습니다.
전체 댓글 조회에 관련되어 많은 로직이 있겠지만, `Stream`객체를 이용하여 긁어오는 방식으로 개발을 진행해보았습니다.
![image](https://github.com/four-uncles/saramara-community-server/assets/84984586/3712622f-5536-4008-a0a5-614aa161dfff)


- [✨ feat: 하나의 댓글 수정](https://github.com/four-uncles/saramara-community-server/commit/120f8c4adeb9e468c83ece9b17ac40517bc3bbcb)
하나의 댓글을 수정하는 API입니다.
`VO클래스` 내부에 부분수정을 할 수 있는 메서드를 배치해 원자값을 흐트러지지않게 개발을 진행했습니다.
`controller`에서 `pathvariable`과 `requestbody`를 같이 받아와 서비스로직에서 메서드체이닝이 일어날 수 있는 코드를 조금 더 정렬시켰습니다.
![image](https://github.com/four-uncles/saramara-community-server/assets/84984586/c0f1238d-96c2-4f2d-bff0-825d16e357de)

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @Jooney-95 @hb9397 @IToriginal 

- close #35 #43 