### PR TITLE
[Feat/메인] 모든 게시글 가져오기

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/board/controller/BoardController.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/controller/BoardController.java
@@ -1,6 +1,7 @@
 package com.kakao.saramaracommunity.board.controller;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
@@ -56,4 +57,33 @@ public class BoardController {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/")
+    public ResponseEntity<Object> readAllBoardsByLatest() {
+        List<BoardResponseDto.ReadAllBoardResponseDto> boards = boardService.readAllBoardsByLatest();
+
+        // 응답 데이터 생성
+        Map<String, Object> response = new HashMap<>();
+        response.put("code", 200);
+        response.put("msg", "success");
+
+        // 게시글 목록
+        response.put("data", boards);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/popular")
+    public ResponseEntity<Object> readAllBoardsByPopularity() {
+        List<BoardResponseDto.ReadAllBoardResponseDto> boards = boardService.readAllBoardsByPopularity();
+
+        // 응답 데이터 생성
+        Map<String, Object> response = new HashMap<>();
+        response.put("code", 200);
+        response.put("msg", "success");
+
+        // 게시글 목록
+        response.put("data", boards);
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/dto/response/BoardResponseDto.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/dto/response/BoardResponseDto.java
@@ -35,4 +35,21 @@ public class BoardResponseDto {
 
         private LocalDateTime deadLine;
     }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class ReadAllBoardResponseDto {
+
+        private String title;
+
+        private String memberNickname;
+
+        private Long boardCnt;
+
+        private Long likeCnt;
+
+        private LocalDateTime deadLine;
+    }
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/entity/Board.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/entity/Board.java
@@ -29,7 +29,7 @@ public class Board extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private CategoryBoard categoryBoard; // 카테고리 (NORMAL, QUESTION ... DEFAULT: NORMAL)
+    private CategoryBoard categoryBoard; // 카테고리 (VOTE, CHOICE ... DEFAULT: VOTE)
 
     @Column(length = 100, nullable = false)
     private String title; // 게시글 제목

--- a/src/main/java/com/kakao/saramaracommunity/board/entity/CategoryBoard.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/entity/CategoryBoard.java
@@ -1,5 +1,5 @@
 package com.kakao.saramaracommunity.board.entity;
 
 public enum CategoryBoard {
-    NORMAL, QUESTION
+    VOTE, CHOICE
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/repository/BoardRepository.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/repository/BoardRepository.java
@@ -9,11 +9,11 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
-    Optional<Board> findByBoardIdAndDeletedAtIsNull(Long boardId);
+    Optional<Board> findByBoardId(Long boardId);
 
-    @Query("SELECT b FROM Board b WHERE b.deletedAt IS NULL ORDER BY b.createdAt DESC")
-    List<Board> findAllByDeletedAtIsNullOrderByCreatedAtDesc();
+    @Query("SELECT b FROM Board b ORDER BY b.createdAt DESC")
+    List<Board> findAllOrderByCreatedAtDesc();
 
-    @Query("SELECT b FROM Board b WHERE b.deletedAt IS NULL ORDER BY b.likeCnt DESC")
-    List<Board> findAllByDeletedAtIsNullOrderByLikeCntDesc();
+    @Query("SELECT b FROM Board b ORDER BY b.likeCnt DESC")
+    List<Board> findAllOrderByLikeCntDesc();
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/repository/BoardRepository.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/repository/BoardRepository.java
@@ -1,11 +1,19 @@
 package com.kakao.saramaracommunity.board.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.kakao.saramaracommunity.board.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
     Optional<Board> findByBoardIdAndDeletedAtIsNull(Long boardId);
+
+    @Query("SELECT b FROM Board b WHERE b.deletedAt IS NULL ORDER BY b.createdAt DESC")
+    List<Board> findAllByDeletedAtIsNullOrderByCreatedAtDesc();
+
+    @Query("SELECT b FROM Board b WHERE b.deletedAt IS NULL ORDER BY b.likeCnt DESC")
+    List<Board> findAllByDeletedAtIsNullOrderByLikeCntDesc();
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/service/BoardService.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/BoardService.java
@@ -1,5 +1,7 @@
 package com.kakao.saramaracommunity.board.service;
 
+import java.util.List;
+
 import com.kakao.saramaracommunity.board.dto.request.BoardRequestDto;
 import com.kakao.saramaracommunity.board.dto.response.BoardResponseDto;
 import com.kakao.saramaracommunity.board.entity.Board;
@@ -11,4 +13,10 @@ public interface BoardService {
 
     // boardId를 매개변수로 받아 해당 게시글을 조회하는 기능의 Method
     BoardResponseDto.ReadOneBoardResponseDto readOneBoard(Long boardId);
+
+    // 게시글 전체를 최신순으로 조회하는 기능의 Method
+    List<BoardResponseDto.ReadAllBoardResponseDto> readAllBoardsByLatest();
+
+    // 게시글 전체를 인기순으로 조회하는 기능의 Method
+    List<BoardResponseDto.ReadAllBoardResponseDto> readAllBoardsByPopularity();
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
@@ -1,6 +1,8 @@
 package com.kakao.saramaracommunity.board.service;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import com.kakao.saramaracommunity.board.dto.request.BoardRequestDto;
 import com.kakao.saramaracommunity.board.dto.response.BoardResponseDto;
@@ -69,5 +71,44 @@ public class BoardServiceImpl implements BoardService {
                 .build();
 
         return responseDto;
+    }
+
+    @Override
+    public List<BoardResponseDto.ReadAllBoardResponseDto> readAllBoardsByLatest() {
+        List<Board> boards = boardRepository.findAllByDeletedAtIsNullOrderByCreatedAtDesc();
+
+        log.info("최신순으로 게시글을 조회합니다.(Reading all boards by latest)");
+
+        return mapBoardListToResponseDtoList(boards);
+    }
+
+    @Override
+    public List<BoardResponseDto.ReadAllBoardResponseDto> readAllBoardsByPopularity() {
+        List<Board> boards = boardRepository.findAllByDeletedAtIsNullOrderByLikeCntDesc();
+
+        log.info("인기순으로 게시글을 조회합니다.(Reading all boards by popularity)");
+
+        return mapBoardListToResponseDtoList(boards);
+    }
+
+    private List<BoardResponseDto.ReadAllBoardResponseDto> mapBoardListToResponseDtoList(List<Board> boards) {
+
+        log.info("게시글 목록을 응답 DTO 목록에 Mapping 합니다.: "
+            + "(Mapping board list to response DTO list)");
+
+        return boards.stream().map(board -> {
+            String memberNickname = board.getMember().getNickname();
+            Long boardCnt = board.getBoardCnt();
+            Long likeCnt = board.getLikeCnt();
+            LocalDateTime deadLine = board.getDeadLine();
+
+            return BoardResponseDto.ReadAllBoardResponseDto.builder()
+                .title(board.getTitle())
+                .memberNickname(memberNickname)
+                .boardCnt(boardCnt)
+                .likeCnt(likeCnt)
+                .deadLine(deadLine)
+                .build();
+        }).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
@@ -49,7 +49,7 @@ public class BoardServiceImpl implements BoardService {
     @Override
     public BoardResponseDto.ReadOneBoardResponseDto readOneBoard(Long boardId) {
 
-        Board board = boardRepository.findByBoardIdAndDeletedAtIsNull(boardId)
+        Board board = boardRepository.findByBoardId(boardId)
             .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
 
         // Member information
@@ -75,7 +75,7 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     public List<BoardResponseDto.ReadAllBoardResponseDto> readAllBoardsByLatest() {
-        List<Board> boards = boardRepository.findAllByDeletedAtIsNullOrderByCreatedAtDesc();
+        List<Board> boards = boardRepository.findAllOrderByCreatedAtDesc();
 
         log.info("최신순으로 게시글을 조회합니다.(Reading all boards by latest)");
 
@@ -84,7 +84,7 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     public List<BoardResponseDto.ReadAllBoardResponseDto> readAllBoardsByPopularity() {
-        List<Board> boards = boardRepository.findAllByDeletedAtIsNullOrderByLikeCntDesc();
+        List<Board> boards = boardRepository.findAllOrderByLikeCntDesc();
 
         log.info("인기순으로 게시글을 조회합니다.(Reading all boards by popularity)");
 


### PR DESCRIPTION
## 🤔 Motivation
- 모든 게시글을 조회하는 기능을 개발 하였습니다.
- 사용자가 게시글의 조회를 최신순, 인기순으로 내용을 확인할 수 있도록 개발하였습니다.
- **최신순 조회** <br> 게시글을 생성한 순서대로(createdAt) 보여주어 사용자들이 최근에 작성된 게시글을 확인할 수 있습니다.
- **인기순 조회** <br> 좋아요 수(likeCnt)가 많은 게시글부터 보여주어 사용자들이 인기 있는 게시글을 우선순위로 확인할 수 있습니다.

<br>

## 💡 Key Changes
- `BoardRepository`에 `findAllByDeletedAtIsNullOrderByCreatedAtDesc()` 메서드를 추가하여 최신순으로 게시글을 조회할 수 있도록 하였습니다.
- `BoardRepository`에 `findAllByDeletedAtIsNullOrderByLikeCntDesc()` 메서드를 추가하여 인기순으로 게시글을 조회할 수 있도록 하였습니다.
- `BoardService` 인터페이스에 `readAllBoardsByLatest()` 메서드를 구현하여 최신순으로 게시글을 조회할 수 있도록 하였습니다.
- `BoardService` 인터페이스에 `readAllBoardsByPopularity()` 메서드를 구현하여 인기순으로 게시글을 조회할 수 있도록 하였습니다.
- `BoardController`에 최신순 조회와 인기순 조회에 해당하는 API를 추가하였습니다. <br> **API Path** <br>  -> 최신순 - `/`, 인기순 - `/popular`

<br>

## ✅ Test
- API 테스트는 PostMan을 통해서 진행했습니다.

**최신순**
<img width="1002" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/117193889/7e189bdb-529f-4c5d-bcdd-1e090f688ab4">

**인기순**
<img width="1002" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/117193889/9d3c807b-9b70-4591-95cb-65979a6f749b">

<br>

## 🧐 Insufficient Content
- 성능에 대한 고민이 있는데, 이 부분은 1차로 설계한 모든 API를 테스트해보면서 진행해볼 예정입니다.
예를 들어 메인에서 Attach의 이미지 파일을 불러오고, 게시글을 조회하게될 텐데, 두 API의 개발을 완료한 뒤에 약 100만의 더미데이터를 넣고 동시에 두개의 성능 테스트를 비교해보는게 어떨까 합니다. 아마 스프린트 5를 진행한 이후에 성능테스트 시간을 잡고 함께 비교해보면서 개선사항을 정리해 나가면 좋을 듯 합니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @Jooney-95 @byeongJoo05 @hb9397 
- 위의 개발 내용에 대한 코드 리뷰 및 피드백 부탁드립니다.
- 추가적으로 개선할 수 있는 부분이나 주의해야 할 사항이 있다면 알려주시면 감사하겠습니다.

close: #40 
