### PR TITLE
[Feat/게시글상세조회 및 메인] 게시글에 대한 이미지 목록 조회

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,6 @@ application-local.yml
 application-dev.yml
 application-prod.yml
 application-test.yml
+
+# local HTTP Client Test
+*.http

--- a/src/main/java/com/kakao/saramaracommunity/attach/controller/AttachController.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/controller/AttachController.java
@@ -6,9 +6,7 @@ import com.kakao.saramaracommunity.attach.service.AttachService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 /**
@@ -30,11 +28,31 @@ public class AttachController {
      * 1장 이상, 최대 5장까지의 이미지를 S3와 MariaDB에 업로드한다.
      *
      * @param request type, id, imgList
-     * @return AttachResponse
+     * @return AttachResponse.UploadResponse
      */
     @PostMapping("/upload")
-    public ResponseEntity<AttachResponse> uploadImage(@Valid AttachRequest.UploadRequest request) {
-        AttachResponse response = attachService.uploadImage(request);
+    public ResponseEntity<AttachResponse.UploadResponse> uploadImage(@RequestBody @Valid AttachRequest.UploadRequest request) {
+        AttachResponse.UploadResponse response = attachService.uploadImage(request);
+        return ResponseEntity.ok().body(response);
+    }
+
+    /**
+     * getImage: 게시글의 등록된 이미지 조회 API
+     * URL: /api/v1/attach/board
+     * 하나의 게시글에 등록된 S3 이미지 주소(URL)를 Map 형태로 응답한다.
+     *
+     * @param request attachType, attachId
+     * @return AttachResponse.GetImageResponse
+     */
+    @GetMapping("/board")
+    public ResponseEntity<AttachResponse.GetImageResponse> getBoardImages(@RequestBody @Valid AttachRequest.GetBoardImageRequest request) {
+        AttachResponse.GetImageResponse response = attachService.getBoardImages(request);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/boards")
+    public ResponseEntity<AttachResponse.GetAllImageResponse> getAllBoardImages() {
+        AttachResponse.GetAllImageResponse response = attachService.getAllBoardImages();
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/kakao/saramaracommunity/attach/controller/AttachController.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/controller/AttachController.java
@@ -50,6 +50,13 @@ public class AttachController {
         return ResponseEntity.ok().body(response);
     }
 
+    /**
+     * getAllBoardImages: 모든 게시글의 등록된 이미지 조회 API
+     * URL: /api/v1/attach/boards
+     * 모든 게시글의 등록된 S3 이미지 주소(URL)를 게시글: 이미지목록(Map) 형태로 응답한다.
+     *
+     * @return AttachResponse.GetAllImageResponse
+     */
     @GetMapping("/boards")
     public ResponseEntity<AttachResponse.GetAllImageResponse> getAllBoardImages() {
         AttachResponse.GetAllImageResponse response = attachService.getAllBoardImages();

--- a/src/main/java/com/kakao/saramaracommunity/attach/dto/request/AttachRequest.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/dto/request/AttachRequest.java
@@ -4,6 +4,7 @@ import com.kakao.saramaracommunity.attach.entity.AttachType;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Map;
@@ -18,27 +19,51 @@ import java.util.Map;
 public class AttachRequest {
 
     /**
-     * UploadRequest: uploadImage 메서드의 요청 데이터를 담을 DTO 클래스
-     * type: 게시글 및 댓글 유형 여부
-     * id: 게시글이나 댓글의 번호(PK)
+     * UploadRequest: 게시글에 대한 이미지를 등록하기 위한 요청 DTO 클래스
+     * attachType: 게시글 및 댓글 유형 여부
+     * ids: 게시글이나 댓글의 번호(PK)
      * imgList: 이미지의 순서(Long)와 이미지 파일(MultipartFile)이 담긴 Map
      */
+    @NoArgsConstructor
     @Getter
     public static class UploadRequest {
 
         @NotNull(message = "어떤 유형의 글에서 이미지가 등록되었는지 알 수 없습니다.")
-        private AttachType type;
+        private AttachType attachType;
 
         @NotNull(message = "게시글이나 댓글의 번호값을 알 수 없습니다.")
-        private Long id;
+        private Long ids;
 
         private Map<Long, MultipartFile> imgList;
 
         @Builder
-        public UploadRequest(AttachType type, Long id, Map<Long, MultipartFile> imgList) {
-            this.type = type;
-            this.id = id;
+        public UploadRequest(AttachType attachType, Long ids, Map<Long, MultipartFile> imgList) {
+            this.attachType = attachType;
+            this.ids = ids;
             this.imgList = imgList;
+        }
+
+    }
+
+    /**
+     * GetBoardImageRequest: 하나의 게시글에 대한 이미지를 가져오기 위한 요청 DTO 클래스
+     * attachType: 게시글 및 댓글 유형 여부
+     * ids: 게시글이나 댓글의 번호(PK)
+     */
+    @NoArgsConstructor
+    @Getter
+    public static class GetBoardImageRequest {
+
+        @NotNull(message = "어떤 유형의 글에서 이미지가 등록되었는지 알 수 없습니다.")
+        AttachType attachType;
+
+        @NotNull(message = "게시글이나 댓글의 번호값을 알 수 없습니다.")
+        Long ids;
+
+        @Builder
+        private GetBoardImageRequest(AttachType attachType, Long ids) {
+            this.attachType = attachType;
+            this.ids = ids;
         }
 
     }

--- a/src/main/java/com/kakao/saramaracommunity/attach/dto/response/AttachResponse.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/dto/response/AttachResponse.java
@@ -3,6 +3,8 @@ package com.kakao.saramaracommunity.attach.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Map;
+
 /**
  * AttachResponse: uploadImage 메서드의 응답 데이터를 담을 DTO 클래스
  *
@@ -12,15 +14,57 @@ import lombok.Getter;
 @Getter
 public class AttachResponse {
 
-    private String code;
-    private String msg;
-    private boolean data;
+    @Getter
+    public static class UploadResponse {
 
-    @Builder
-    public AttachResponse(String code, String msg, boolean data) {
-        this.code = code;
-        this.msg = msg;
-        this.data = data;
+        private String code;
+
+        private String msg;
+
+        private boolean data;
+
+        @Builder
+        private UploadResponse(String code, String msg, boolean data) {
+            this.code = code;
+            this.msg = msg;
+            this.data = data;
+        }
+    }
+
+    @Getter
+    public static class GetImageResponse {
+
+        private String code;
+
+        private String msg;
+
+        private Map<Long, String> data;
+
+        @Builder
+        private GetImageResponse(String code, String msg, Map<Long, String> data) {
+            this.code = code;
+            this.msg = msg;
+            this.data = data;
+        }
+
+    }
+
+    @Getter
+    public static class GetAllImageResponse {
+
+        private String code;
+
+        private String msg;
+
+        private Map<Long, Map<Long, String>> data;
+
+        @Builder
+        private GetAllImageResponse(String code, String msg, Map<Long, Map<Long, String>> data) {
+            this.code = code;
+            this.msg = msg;
+            this.data = data;
+        }
+
     }
 
 }

--- a/src/main/java/com/kakao/saramaracommunity/attach/entity/Attach.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/entity/Attach.java
@@ -34,7 +34,7 @@ public class Attach extends BaseTimeEntity {
     private AttachType type;
 
     @Column(nullable = false)
-    private Long id;
+    private Long ids;
 
     @Column(nullable = false)
     private Long seq;
@@ -43,9 +43,9 @@ public class Attach extends BaseTimeEntity {
     private String imgPath;
 
     @Builder
-    public Attach(AttachType type, Long id, Long seq, String imgPath) {
+    public Attach(AttachType type, Long ids, Long seq, String imgPath) {
         this.type = type;
-        this.id = id;
+        this.ids = ids;
         this.seq = seq;
         this.imgPath = imgPath;
     }

--- a/src/main/java/com/kakao/saramaracommunity/attach/repository/AttachRepository.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/repository/AttachRepository.java
@@ -3,6 +3,9 @@ package com.kakao.saramaracommunity.attach.repository;
 import com.kakao.saramaracommunity.attach.entity.Attach;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AttachRepository extends JpaRepository<Attach, Long> {
 
+    List<Attach> findAllByIds(Long id);
 }

--- a/src/main/java/com/kakao/saramaracommunity/attach/service/AttachService.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/service/AttachService.java
@@ -12,6 +12,9 @@ import com.kakao.saramaracommunity.attach.dto.response.AttachResponse;
  */
 public interface AttachService {
 
-    AttachResponse uploadImage(AttachRequest.UploadRequest request);
+    AttachResponse.UploadResponse uploadImage(AttachRequest.UploadRequest request);
 
+    AttachResponse.GetImageResponse getBoardImages(AttachRequest.GetBoardImageRequest request);
+
+    AttachResponse.GetAllImageResponse getAllBoardImages();
 }

--- a/src/test/java/com/kakao/saramaracommunity/attach/service/AttachServiceImplTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/attach/service/AttachServiceImplTest.java
@@ -2,7 +2,9 @@ package com.kakao.saramaracommunity.attach.service;
 
 import com.kakao.saramaracommunity.attach.dto.request.AttachRequest;
 import com.kakao.saramaracommunity.attach.dto.response.AttachResponse;
+import com.kakao.saramaracommunity.attach.entity.Attach;
 import com.kakao.saramaracommunity.attach.entity.AttachType;
+import com.kakao.saramaracommunity.attach.repository.AttachRepository;
 import com.kakao.saramaracommunity.config.AwsS3MockConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.kakao.saramaracommunity.attach.entity.AttachType.BOARD;
@@ -36,6 +39,9 @@ import static org.junit.jupiter.api.Assertions.*;
 class AttachServiceImplTest {
 
     @Autowired
+    AttachRepository attachRepository;
+
+    @Autowired
     private AttachService attachService;
 
     @BeforeEach
@@ -44,6 +50,7 @@ class AttachServiceImplTest {
 
     @AfterEach
     void tearDown() {
+        attachRepository.deleteAllInBatch();
     }
 
     @DisplayName("1장의 이미지를 업로드하면 S3와 DB에 이미지가 업로드된다.")
@@ -55,13 +62,13 @@ class AttachServiceImplTest {
         imgList.put(1L, file);
 
         AttachRequest.UploadRequest request = AttachRequest.UploadRequest.builder()
-                .type(BOARD)
-                .id(1L)
+                .attachType(BOARD)
+                .ids(1L)
                 .imgList(imgList)
                 .build();
 
         // when
-        AttachResponse response = attachService.uploadImage(request);
+        AttachResponse.UploadResponse response = attachService.uploadImage(request);
 
         // then
         assertThat(response.getCode()).isEqualTo("200 OK");
@@ -86,13 +93,13 @@ class AttachServiceImplTest {
         imgList.put(5L, file5);
 
         AttachRequest.UploadRequest request = AttachRequest.UploadRequest.builder()
-                .type(BOARD)
-                .id(1L)
+                .attachType(BOARD)
+                .ids(1L)
                 .imgList(imgList)
                 .build();
 
         // when
-        AttachResponse response = attachService.uploadImage(request);
+        AttachResponse.UploadResponse response = attachService.uploadImage(request);
 
         // then
         assertThat(response.getCode()).isEqualTo("200 OK");
@@ -107,16 +114,17 @@ class AttachServiceImplTest {
         Map<Long, MultipartFile> imgList = new HashMap<>();
 
         AttachRequest.UploadRequest request = AttachRequest.UploadRequest.builder()
-                .type(BOARD)
-                .id(1L)
+                .attachType(BOARD)
+                .ids(1L)
                 .imgList(imgList)
                 .build();
 
         // when
-        AttachResponse response = attachService.uploadImage(request);
+        AttachResponse.UploadResponse response = attachService.uploadImage(request);
 
         // then
-        assertThat(response.getCode()).isEqualTo("200 OK");
+        assertThat(response.getCode()).isEqualTo("400 BAD_REQUEST");
+        assertThat(response.getMsg()).isEqualTo("이미지는 1장 이상, 최대 5장까지 등록할 수 있습니다.");
         assertThat(response.isData()).isFalse();
 
     }
@@ -140,18 +148,100 @@ class AttachServiceImplTest {
         imgList.put(6L, file6);
 
         AttachRequest.UploadRequest request = AttachRequest.UploadRequest.builder()
-                .type(BOARD)
-                .id(1L)
+                .attachType(BOARD)
+                .ids(1L)
                 .imgList(imgList)
                 .build();
 
         // when
-        AttachResponse response = attachService.uploadImage(request);
+        AttachResponse.UploadResponse response = attachService.uploadImage(request);
 
         // then
-        assertThat(response.getCode()).isEqualTo("200 OK");
+        assertThat(response.getCode()).isEqualTo("400 BAD_REQUEST");
+        assertThat(response.getMsg()).isEqualTo("이미지는 1장 이상, 최대 5장까지 등록할 수 있습니다.");
         assertThat(response.isData()).isFalse();
 
     }
+
+    @DisplayName("하나의 게시글에 등록된 이미지 목록을 조회한다.")
+    @Test
+    void getBoardImages() {
+
+        // given
+        Attach attach1 = createAttach(1L, 1L, "test1.jpg");
+        Attach attach2 = createAttach(1L, 2L, "test2.jpg");
+        Attach attach3 = createAttach(1L, 3L, "test3.jpg");
+        attachRepository.saveAll(List.of(attach1, attach2, attach3));
+
+        AttachRequest.GetBoardImageRequest request = AttachRequest.GetBoardImageRequest.builder()
+                .attachType(BOARD)
+                .ids(1L)
+                .build();
+
+        // when
+        AttachResponse.GetImageResponse response = attachService.getBoardImages(request);
+
+        // then
+        assertThat(response.getCode()).isEqualTo("200 OK");
+        assertThat(response.getMsg()).isEqualTo("정상적으로 해당 게시글의 등록된 이미지 목록을 조회하였습니다.");
+        assertThat(response.getData()).hasSize(3);
+        assertThat(response.getData().keySet()).containsExactly(1L, 2L, 3L);
+        assertThat(response.getData().values()).containsExactly("test1.jpg", "test2.jpg", "test3.jpg");
+
+    }
+
+    @DisplayName("모든 게시글에 등록된 이미지 목록을 조회한다.")
+    @Test
+    void getAllBoardImages() {
+
+        // given
+
+        // first board attachs
+        Attach firstBoardAttach1 = createAttach(1L, 1L, "first1.jpg");
+        Attach firstBoardAttach2 = createAttach(1L, 2L, "first2.jpg");
+        Attach firstBoardAttach3 = createAttach(1L, 3L, "first3.jpg");
+
+        // second board attachs
+        Attach secondBoardAttach1 = createAttach(2L, 1L, "sec1.jpg");
+        Attach secondBoardAttach2 = createAttach(2L, 2L, "sec2.jpg");
+        Attach secondBoardAttach3 = createAttach(2L, 3L, "sec3.jpg");
+        Attach secondBoardAttach4 = createAttach(2L, 4L, "sec4.jpg");
+
+        // third board attachs
+        Attach thirdBoardAttach1 = createAttach(3L, 1L, "third1.jpg");
+
+        attachRepository.saveAll(
+                List.of(
+                        firstBoardAttach1,
+                        firstBoardAttach2,
+                        firstBoardAttach3,
+                        secondBoardAttach1,
+                        secondBoardAttach2,
+                        secondBoardAttach3,
+                        secondBoardAttach4,
+                        thirdBoardAttach1
+                )
+        );
+
+        // when
+        AttachResponse.GetAllImageResponse response = attachService.getAllBoardImages();
+
+        // then
+        assertThat(response.getCode()).isEqualTo("200 OK");
+        assertThat(response.getMsg()).isEqualTo("정상적으로 모든 게시글의 등록된 이미지 목록을 조회하였습니다.");
+        assertThat(response.getData().keySet()).containsExactly(1L, 2L, 3L);
+        assertThat(response.getData().keySet()).hasSize(3);
+
+    }
+
+    private Attach createAttach(Long ids, Long seq, String path) {
+        return Attach.builder()
+                .type(BOARD)
+                .ids(ids)
+                .seq(seq)
+                .imgPath(path)
+                .build();
+    }
+
 
 }


### PR DESCRIPTION
## 🤔 Motivation
- Sprint-2: 하나의 게시글에 대한 이미지 조회 기능 개발
- Sprint-3: 모든 게시글에 대한 이미지 조회 기능 개발

<br>

## 💡 Key Changes

### 하나의 게시글 이미지 목록
- `/api/v1/attach/board` URL로 게시글 번호(PK)를 요청으로 받는다면, 등록된 이미지 목록을 Map 형태로 반환하는 조회 기능을 개발했습니다.
- 반환하는 이미지 목록 타입은 `Map<Long, String>`이며 `이미지 순서: S3 URL` 형태의 Map 목록으로 응답합니다.

> `attachType` 필드의 경우 본래 게시글이나 댓글의 이미지 업로드를 구분하기 위하여 설계한 필드이나 현재 댓글의 이미지 업로드 여부가 명확하지 않아 구현에 활용하지는 않았음을 알립니다.

<br>

### 모든 게시글의 이미지 목록
- `/api/v1/attach/boards` URL로 요청을 받는다면 모든 게시글의 등록된 이미지 목록을 Map 형태로 반환하는 조회 기능을 개발했습니다.
- 반환하는 이미지 목록 타입은 `Map<Long, Map<Long, String>>`이며 `게시글번호: (이미지순서: S3 URL)` 형태의 이중 Map 목록으로 응답하게 됩니다.  

<br>

### 🛠️ 테스트 관련
- 비즈니스 로직에 특별한 연산을 하는 로직을 메스다 단위로 분리한 후, 단위 테스트를 진행해야 했으나 단위 테스트 학습이 미흡하여 **통합 테스트 위주의 테스트 코드 작성**만을 진행했음을 알립니다.

<img width="863" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/59594946/ec3e14fd-9027-4f7a-acee-0b9d37e5b004">

조회 테스트케이스의 경우 해피케이스 2가지 테스트케이스를 추가했고, 위와 같이 테스트가 정상적으로 성공했음을 확인했습니다.

<br>

### 💬 아쉬운 점
- 비즈니스 로직에서의 `try/catch`문을 제거하려 했으나 시간 부족으로 인해 제거하지 못했습니다.
- 비즈니스 로직에서 각 서비스 메서드마다 유효한 로직을 분리하지 못했습니다.
- Request, Response DTO 클래스나 Controller, Service에서 개발한 주요 메서드의 네이밍이 아쉽습니다.
    - 단일 이미지 목록 조회의 경우 `getBoardImages`, 모든 이미지 목록 조회의 경우 `getAllBoardImages` 와 같이 조금 어색합니다.

<br>

### 🤔 후기

이번 스프린트에서는 팀원들과의 개발 관련 소통이 부족했음을 고백합니다. 

이미지 처리와 관련된 로직뿐만 아니라 기획하고 설계한 사항들에 대해서 아직 미비한 부분이 많음에도 맡은 역할만 겨우 수행했던 것 같습니다. 다음 스프린트에서는 조금 더 신경쓰고 적극적인 소통을 하도록 하겠습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @byeongJoo05 @hb9397 @IToriginal 

close #32 
close #41 
