### PR TITLE
[Feat/게시글수정] 게시글 수정하기

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/board/controller/BoardController.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/controller/BoardController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -85,5 +86,20 @@ public class BoardController {
         response.put("data", boards);
 
         return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{boardId}")
+    public ResponseEntity<Object> updateBoard(@PathVariable ("boardId") Long boardId,
+        @RequestBody @Valid BoardRequestDto.UpdateRequestDto requestDto) {
+
+        Boolean result = boardService.updateBoard(boardId, requestDto);
+
+        // 응답 데이터 생성
+        Map<String, Object> response = new HashMap<>();
+        response.put("code", 200);
+        response.put("msg", "success");
+        response.put("result", result);
+
+        return ResponseEntity.status((int)response.get("code")).body(response);
     }
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/dto/request/BoardRequestDto.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/dto/request/BoardRequestDto.java
@@ -35,4 +35,23 @@ public class BoardRequestDto {
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime deadLine;
     }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Builder
+    public static class UpdateRequestDto {
+
+        @NotBlank(message = "제목을 입력해주세요.")
+        private String title;
+
+        @NotBlank(message = "내용을 입력해주세요.")
+        private String content;
+
+        @NotNull(message = "카테고리를 선택해주세요.")
+        private CategoryBoard categoryBoard;
+
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime deadLine;
+    }
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/entity/Board.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/entity/Board.java
@@ -66,4 +66,20 @@ public class Board extends BaseTimeEntity {
         this.boardCnt = this.boardCnt == null ? 0 : this.boardCnt;
         this.likeCnt = this.likeCnt == null ? 0 : this.likeCnt;
     }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public void setCategoryBoard(CategoryBoard categoryBoard) {
+        this.categoryBoard = categoryBoard;
+    }
+
+    public void setDeadLine(LocalDateTime deadLine) {
+        this.deadLine = deadLine;
+    }
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/service/BoardService.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/BoardService.java
@@ -19,4 +19,7 @@ public interface BoardService {
 
     // 게시글 전체를 인기순으로 조회하는 기능의 Method
     List<BoardResponseDto.ReadAllBoardResponseDto> readAllBoardsByPopularity();
+
+    // 게시글 수정 요청 Method
+    Boolean updateBoard(Long boardId, BoardRequestDto.UpdateRequestDto requestDto);
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
@@ -111,4 +111,25 @@ public class BoardServiceImpl implements BoardService {
                 .build();
         }).collect(Collectors.toList());
     }
+
+    @Override
+    public Boolean updateBoard(Long boardId,
+        BoardRequestDto.UpdateRequestDto requestDto) {
+
+        Board board = boardRepository.findByBoardId(boardId)
+            .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
+
+        log.info("요청에 따라 게시글을 수정합니다.(Update the post as requested.)");
+
+        // 요청된 데이터로 수정할 내용 업데이트
+        board.setTitle(requestDto.getTitle());
+        board.setContent(requestDto.getContent());
+        board.setCategoryBoard(requestDto.getCategoryBoard());
+        board.setDeadLine(requestDto.getDeadLine());
+
+        // 수정된 게시글을 저장
+        boardRepository.save(board);
+
+        return true;
+    }
 }


### PR DESCRIPTION
## 🤔 Motivation
- 사용자의 요청에 따라 등록된 게시글에 대한 수정 기능을 개발 하였습니다.

<br>

## 💡 Key Changes
- 게시글 수정 처리를 위해 `BoardController` class에 `@PatchMapping` 메서드를 추가하였습니다.
- 게시글 수정에 필요한 제목, 내용, 카테고리, 마감 시간을 수정할 수 있게 하기 위해서 `setTitle`, `setContent`, `setCategoryBoard`, `setDeadLine` 메서드를 추가하였습니다.
- `BoardService` 인터페이스에 `updateBoard` 메서드를 추가하였습니다.
- `BoardServiceImpl` 클래스에 `updateBoard` 메서드를 구현하였습니다. 이 메서드는 요청된 데이터로 게시글을 수정하고 저장합니다.
- `RequestDto` 클래스에 `UpdateRequestDto` 이너 클래스를 추가하였습니다. 이 클래스를 통해서 게시글 수정 시 요청되는 데이터를 담습니다.

<br>

## ✅ Test
- API 테스트는 PostMan을 통해서 진행했습니다.
<img width="891" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/117193889/cccf9c5b-d2ed-4127-871c-2affb34d6518">

위의 그림과 같이 수정이 필요한 부분을 수정하고 API를 호출하게 되면 아래와 같이 수정이 이루어진 것을 확인할 수 있습니다.

<img width="891" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/117193889/3a0ded49-9b7d-4401-b9e2-5a0125367b75">

### 한 개의 게시글 조회 API를 통해 수정이 잘 이루졌는지 확인
<img width="1000" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/117193889/0b0d140e-b34f-4274-98cc-951060c9603e">

<br>

## 🧐 Insufficient Content
- 처음에는 data를 통해 모든 data를 불러와서 응답값을 주었지만, 수정에 또 다시 데이터를 응답할 필요성을 느끼지 못해서,
병주님이 개발하셨던 방법인 Boolean을 통해서 true 값을 응답하도록 하였습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @langoustinee @byeongJoo05 @hb9397 
- 위의 개발 내용에 대한 코드 리뷰 및 피드백 부탁드립니다.
- 추가적으로 개선할 수 있는 부분이나 주의해야 할 사항이 있다면 알려주시면 감사하겠습니다.

close: #50 
