### PR TITLE
[Feat/게시글 삭제] 게시글 삭제하기

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/board/controller/BoardController.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/controller/BoardController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -101,5 +102,17 @@ public class BoardController {
         response.put("result", result);
 
         return ResponseEntity.status((int)response.get("code")).body(response);
+    }
+
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<Map<String, Object>> deleteBoard(@PathVariable ("boardId") Long boardId) {
+
+        Boolean deletedBoard = boardService.deleteBoard(boardId);
+
+        Map<String, Object> result = new HashMap<>();
+
+        result.put("result", deletedBoard);
+
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/service/BoardService.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/BoardService.java
@@ -22,4 +22,7 @@ public interface BoardService {
 
     // 게시글 수정 요청 Method
     Boolean updateBoard(Long boardId, BoardRequestDto.UpdateRequestDto requestDto);
+
+    // 게시글 삭제 요청 Method
+    Boolean deleteBoard(Long boardId);
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
@@ -132,4 +132,15 @@ public class BoardServiceImpl implements BoardService {
 
         return true;
     }
+
+    @Override
+    public Boolean deleteBoard(Long boardId) {
+
+        if (boardRepository.findByBoardId(boardId).isPresent()) {
+            boardRepository.deleteById(boardId);
+            log.info("요청에 따라 게시글을 삭제합니다. (Delete the post as requested)");
+            return true;
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
## 🤔 Motivation
- 게시글 삭제 기능을 추가하고, 해당 기능을 위한 Service와 Controller 메서드를 구현하였습니다.
- 게시글 삭제의 경우는 Soft Delete 방식으로 구현하였습니다.

<br>

## 💡 Key Changes
- BoardService 인터페이스에 deleteBoard(Long boardId) 메서드를 추가합니다.
- BoardServiceImpl 클래스에 deleteBoard(Long boardId) 메서드를 구현합니다. 해당 메서드는 요청된 boardId에 해당하는 게시글을 삭제합니다.
- Controller 클래스에 @DeleteMapping을 사용하여 deleteBoard(Long boardId) 메서드를 추가합니다. 해당 메서드는 요청된 boardId를 통해 게시글을 삭제하고 결과를 응답합니다.

<br>

## ✅ Test
- API 테스트는 PostMan을 통해서 진행했습니다.
<img width="1008" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/117193889/a19ac3a4-d3d0-439b-b1ba-92f09651cf78">
앞서 구현한 기능인 "한개의 게시글 조회 API"를 통해 boarId가 2인 게시물을 조회하여 해당 게시글이 존재하는지 확인합니다.
<br>
<br>

<img width="1007" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/117193889/38dc2639-f506-4032-aae1-3c9793195cb8">
이제 boardId가 2인 게시물을 삭제하기 위해서 이번에 추가한 deleteBoard 메서드를 호출할 API를 사용하여 글을 삭제해보았습니다.
<br>
<br>

<img width="1468" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/117193889/8c52ff96-daba-4c74-a9d2-bdb901f02bee">
DBeaver를 통해서 DataBase에 `SELECT * FROM board;`을 통해 확인해보면 deleted_at에 삭제 시간이 들어가있는 것을 확인할 수 있습니다.

<br>
<br>

## 🧐 Insufficient Content
- 삭제에 대해서도 기본적인 CRUD 작업이라 어려움은 없었습니다. 하지만, 예외처리나 부분적으로 추가할 사항들이 보이는데 리팩토링을 계획한 기간이 있기 때문에 리팩토링 부분에서 이 부분들을 잡을 예정입니다. (예외처리, 응답처리, 페이징처리, Test 코드 작성)

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @langoustinee @byeongJoo05 @hb9397 
- 위의 개발 내용에 대한 코드 리뷰 및 피드백 부탁드립니다.
- 추가적으로 개선할 수 있는 부분이나 주의해야 할 사항이 있다면 알려주시면 감사하겠습니다.

close: #56 