### PR TITLE
[Feat/게시글등록∙수정∙삭제] 이미지 업로드 API 분리 및 수정/삭제 API 개발

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/attach/controller/AttachController.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/controller/AttachController.java
@@ -23,22 +23,49 @@ public class AttachController {
     private final AttachService attachService;
 
     /**
-     * uploadImage: 이미지 업로드 API
-     * URL: /api/v1/attach/upload
+     * uploadImageDeprecated: 이미지 업로드 API
+     * URL: POST /api/v1/attach/upload
      * 1장 이상, 최대 5장까지의 이미지를 S3와 MariaDB에 업로드한다.
      *
      * @param request type, id, imgList
      * @return AttachResponse.UploadResponse
      */
-    @PostMapping("/upload")
-    public ResponseEntity<AttachResponse.UploadResponse> uploadImage(@RequestBody @Valid AttachRequest.UploadRequest request) {
-        AttachResponse.UploadResponse response = attachService.uploadImage(request);
+    @PostMapping("/upload/deprecated")
+    public ResponseEntity<AttachResponse.UploadResponse> uploadImageDeprecated(@RequestBody @Valid AttachRequest.UploadRequestDeprecated request) {
+        AttachResponse.UploadResponse response = attachService.uploadImageDeprecated(request);
         return ResponseEntity.ok().body(response);
     }
 
     /**
+     * uploadS3BucketImages: AWS S3 Bucket 이미지 파일 등록 API
+     * URL: POST /api/v1/attach/upload/bucket
+     *
+     * @param request type, id, imgList
+     * @return AttachResponse.UploadBucketResponse
+     */
+    @PostMapping("/upload/bucket")
+    public ResponseEntity<AttachResponse.UploadBucketResponse> uploadS3BucketImages(@RequestBody @Valid AttachRequest.UploadBucketRequest request) {
+        AttachResponse.UploadBucketResponse response = attachService.uploadS3BucketImages(request);
+        return ResponseEntity.ok().body(response);
+    }
+
+    /**
+     * uploadImages: AWS S3 Bucket 이미지 파일 등록 API
+     * URL: POST /api/v1/attach/upload/bucket
+     *
+     * @param request type, id, imgList
+     * @return AttachResponse.UploadBucketResponse
+     */
+    @PostMapping("/upload")
+    public ResponseEntity<AttachResponse.UploadResponse> uploadImages(@RequestBody @Valid AttachRequest.UploadRequest request) {
+        AttachResponse.UploadResponse response = attachService.uploadImages(request);
+        return ResponseEntity.ok().body(response);
+    }
+
+
+    /**
      * getImage: 게시글의 등록된 이미지 조회 API
-     * URL: /api/v1/attach/board
+     * URL: GET /api/v1/attach/board
      * 하나의 게시글에 등록된 S3 이미지 주소(URL)를 Map 형태로 응답한다.
      *
      * @param request attachType, attachId
@@ -52,7 +79,7 @@ public class AttachController {
 
     /**
      * getAllBoardImages: 모든 게시글의 등록된 이미지 조회 API
-     * URL: /api/v1/attach/boards
+     * URL: GET /api/v1/attach/boards
      * 모든 게시글의 등록된 S3 이미지 주소(URL)를 게시글: 이미지목록(Map) 형태로 응답한다.
      *
      * @return AttachResponse.GetAllImageResponse
@@ -62,5 +89,30 @@ public class AttachController {
         AttachResponse.GetAllImageResponse response = attachService.getAllBoardImages();
         return ResponseEntity.ok().body(response);
     }
+
+    /**
+     * updateImage: 게시글의 등록된 하나의 이미지 수정 API
+     * URL: PUT /api/v1/attach/board
+     *
+     * @return AttachResponse.UpdateResponse
+     */
+    @PutMapping("/board")
+    public ResponseEntity<AttachResponse.UpdateResponse> updateImage(@RequestBody @Valid AttachRequest.UpdateRequest request) {
+        AttachResponse.UpdateResponse response = attachService.updateImage(request);
+        return ResponseEntity.ok().body(response);
+    }
+
+    /**
+     * deleteImage: 게시글의 등록된 하나의 이미지 삭제 API
+     * URL: DELETE /api/v1/attach/board
+     *
+     * @return AttachResponse.DeleteResponse
+     */
+    @DeleteMapping("/board")
+    public ResponseEntity<AttachResponse.DeleteResponse> deleteImage(@Valid @PathVariable Long attachId) {
+        AttachResponse.DeleteResponse response = attachService.deleteImage(attachId);
+        return ResponseEntity.ok().body(response);
+    }
+
 
 }

--- a/src/main/java/com/kakao/saramaracommunity/attach/dto/request/AttachRequest.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/dto/request/AttachRequest.java
@@ -2,11 +2,13 @@ package com.kakao.saramaracommunity.attach.dto.request;
 
 import com.kakao.saramaracommunity.attach.entity.AttachType;
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -19,14 +21,14 @@ import java.util.Map;
 public class AttachRequest {
 
     /**
-     * UploadRequest: 게시글에 대한 이미지를 등록하기 위한 요청 DTO 클래스
+     * UploadRequestDeprecated: 게시글에 대한 이미지를 등록하기 위한 요청 DTO 클래스
      * attachType: 게시글 및 댓글 유형 여부
      * ids: 게시글이나 댓글의 번호(PK)
      * imgList: 이미지의 순서(Long)와 이미지 파일(MultipartFile)이 담긴 Map
      */
-    @NoArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @Getter
-    public static class UploadRequest {
+    public static class UploadRequestDeprecated {
 
         @NotNull(message = "어떤 유형의 글에서 이미지가 등록되었는지 알 수 없습니다.")
         private AttachType attachType;
@@ -37,7 +39,7 @@ public class AttachRequest {
         private Map<Long, MultipartFile> imgList;
 
         @Builder
-        public UploadRequest(AttachType attachType, Long ids, Map<Long, MultipartFile> imgList) {
+        public UploadRequestDeprecated(AttachType attachType, Long ids, Map<Long, MultipartFile> imgList) {
             this.attachType = attachType;
             this.ids = ids;
             this.imgList = imgList;
@@ -46,11 +48,53 @@ public class AttachRequest {
     }
 
     /**
+     * UploadRequest: 게시글에 대한 이미지를 등록하기 위한 요청 DTO 클래스
+     * attachType: 게시글 및 댓글 유형 여부
+     * ids: 게시글이나 댓글의 번호(PK)
+     * imgList: 이미지의 순서(Long)와 S3 이미지 객체 URL(String)이 담긴 Map
+     */
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Getter
+    public static class UploadRequest {
+
+        @NotNull(message = "어떤 유형의 글에서 이미지가 등록되었는지 알 수 없습니다.")
+        private AttachType attachType;
+
+        @NotNull(message = "게시글이나 댓글의 번호값을 알 수 없습니다.")
+        private Long ids;
+
+        private Map<Long, String> imgList;
+
+        @Builder
+        public UploadRequest(AttachType attachType, Long ids, Map<Long, String> imgList) {
+            this.attachType = attachType;
+            this.ids = ids;
+            this.imgList = imgList;
+        }
+
+    }
+
+    /**
+     * UploadBucketRequest: 게시글의 이미지 목록을 AWS S3에 등록하기 위한 요청 DTO 클래스
+     * imgList: 이미지 파일(MultipartFile)이 담긴 ArrayList
+     */
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Getter
+    public static class UploadBucketRequest {
+        private List<MultipartFile> imgList;
+
+        @Builder
+        private UploadBucketRequest(List<MultipartFile> imgList) {
+            this.imgList = imgList;
+        }
+    }
+
+    /**
      * GetBoardImageRequest: 하나의 게시글에 대한 이미지를 가져오기 위한 요청 DTO 클래스
      * attachType: 게시글 및 댓글 유형 여부
      * ids: 게시글이나 댓글의 번호(PK)
      */
-    @NoArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @Getter
     public static class GetBoardImageRequest {
 
@@ -66,6 +110,37 @@ public class AttachRequest {
             this.ids = ids;
         }
 
+    }
+
+    /**
+     * UpdateRequest: 하나의 게시글에 대한 이미지를 수정하기 위한 요청 DTO 클래스
+     * attachType: 게시글 및 댓글 유형 여부
+     * ids: 게시글이나 댓글의 번호(PK)
+     * imgList: 이미지의 순서(Long)와 S3 이미지 객체 URL(String)이 담긴 Map
+     *
+     */
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Getter
+    public static class UpdateRequest {
+
+        @NotNull(message = "이미지 첨부파일 번호를 알 수 없습니다.")
+        private Long attachId;
+
+        @NotNull(message = "어떤 유형의 글에서 이미지가 등록되었는지 알 수 없습니다.")
+        private AttachType attachType;
+
+        @NotNull(message = "게시글이나 댓글의 번호값을 알 수 없습니다.")
+        private Long ids;
+
+        private String imgPath;
+
+        @Builder
+        private UpdateRequest(Long attachId, AttachType attachType, Long ids, String imgPath) {
+            this.attachId = attachId;
+            this.attachType = attachType;
+            this.ids = ids;
+            this.imgPath = imgPath;
+        }
     }
 
 }

--- a/src/main/java/com/kakao/saramaracommunity/attach/dto/response/AttachResponse.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/dto/response/AttachResponse.java
@@ -3,6 +3,7 @@ package com.kakao.saramaracommunity.attach.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -13,6 +14,7 @@ import java.util.Map;
  */
 @Getter
 public class AttachResponse {
+
 
     @Getter
     public static class UploadResponse {
@@ -29,6 +31,25 @@ public class AttachResponse {
             this.msg = msg;
             this.data = data;
         }
+
+    }
+
+    @Getter
+    public static class UploadBucketResponse {
+
+        private String code;
+
+        private String msg;
+
+        private List<String> data;
+
+        @Builder
+        private UploadBucketResponse(String code, String msg, List<String> data) {
+            this.code = code;
+            this.msg = msg;
+            this.data = data;
+        }
+
     }
 
     @Getter
@@ -38,10 +59,10 @@ public class AttachResponse {
 
         private String msg;
 
-        private Map<Long, String> data;
+        private Map<Long, Map<Long, String>> data;
 
         @Builder
-        private GetImageResponse(String code, String msg, Map<Long, String> data) {
+        private GetImageResponse(String code, String msg, Map<Long, Map<Long, String>> data) {
             this.code = code;
             this.msg = msg;
             this.data = data;
@@ -67,4 +88,37 @@ public class AttachResponse {
 
     }
 
+    @Getter
+    public static class UpdateResponse {
+
+        private String code;
+
+        private String msg;
+
+        private boolean data;
+
+        @Builder
+        private UpdateResponse(String code, String msg, boolean data) {
+            this.code = code;
+            this.msg = msg;
+            this.data = data;
+        }
+    }
+
+    @Getter
+    public static class DeleteResponse {
+
+        private String code;
+
+        private String msg;
+
+        private boolean data;
+
+        @Builder
+        private DeleteResponse(String code, String msg, boolean data) {
+            this.code = code;
+            this.msg = msg;
+            this.data = data;
+        }
+    }
 }

--- a/src/main/java/com/kakao/saramaracommunity/attach/entity/Attach.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/entity/Attach.java
@@ -50,4 +50,13 @@ public class Attach extends BaseTimeEntity {
         this.imgPath = imgPath;
     }
 
+    /**
+     * changeImgPath: 이미지 URL 수정 메서드
+     *
+     * @param imgPath
+     */
+    public void changeImgPath(String imgPath) {
+        this.imgPath = imgPath;
+    }
+
 }

--- a/src/main/java/com/kakao/saramaracommunity/attach/service/AttachService.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/service/AttachService.java
@@ -12,9 +12,18 @@ import com.kakao.saramaracommunity.attach.dto.response.AttachResponse;
  */
 public interface AttachService {
 
-    AttachResponse.UploadResponse uploadImage(AttachRequest.UploadRequest request);
+    AttachResponse.UploadResponse uploadImageDeprecated(AttachRequest.UploadRequestDeprecated request);
+
+    AttachResponse.UploadBucketResponse uploadS3BucketImages(AttachRequest.UploadBucketRequest request);
+
+    AttachResponse.UploadResponse uploadImages(AttachRequest.UploadRequest request);
 
     AttachResponse.GetImageResponse getBoardImages(AttachRequest.GetBoardImageRequest request);
 
     AttachResponse.GetAllImageResponse getAllBoardImages();
+
+    AttachResponse.UpdateResponse updateImage(AttachRequest.UpdateRequest request);
+
+    AttachResponse.DeleteResponse deleteImage(Long attachId);
+
 }

--- a/src/main/java/com/kakao/saramaracommunity/attach/service/AttachServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/service/AttachServiceImpl.java
@@ -12,15 +12,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
  * AttachServiceImpl: 이미지 첨부파일 관련 비즈니스 로직을 수행할 AttachService 서비스 인터페이스의 구현체 클래스
- *
  * 비즈니스 로직 내부에서 전역 예외 처리에 대한 부분과 로그 출력이 미흡한 상태입니다.
  *
  * @author Taejun
@@ -36,14 +32,14 @@ public class AttachServiceImpl implements AttachService {
     private final AwsS3Uploader awsS3Uploader;
 
     /**
-     * uploadMultipleImage: 1장 이상의 이미지를 S3 버킷에 업로드 한후, ATTACH 테이블에 저장하는 메서드
+     * uploadImageDeprecated: 1장 이상의 이미지를 S3 버킷에 업로드 한후, ATTACH 테이블에 저장하는 메서드
      * request의 이미지 순서와 파일이 담긴 Map을 파싱하여 List에 담은 후 ATTACH 테이블에 삽입
      *
      * @param request type, id, imgList
      * @return AttachResponse.UploadResponse
      */
     @Override
-    public AttachResponse.UploadResponse uploadImage(AttachRequest.UploadRequest request) {
+    public AttachResponse.UploadResponse uploadImageDeprecated(AttachRequest.UploadRequestDeprecated request) {
 
         try {
 
@@ -98,7 +94,121 @@ public class AttachServiceImpl implements AttachService {
     }
 
     /**
+     * uploadS3BucketImage: 1장 이상의 이미지를 S3 버킷에 등록하는 메서드
+     * request의 이미지 파일을 AWS S3 버킷에 등록하여 반환받은 객체 URL을 List에 담아 반환
+     *
+     * @param request List<Multipartfile> imgList
+     * @return AttachResponse.UploadBucketResponse
+     */
+    @Override
+    public AttachResponse.UploadBucketResponse uploadS3BucketImages(AttachRequest.UploadBucketRequest request) {
+
+        try {
+
+            List<MultipartFile> imgList = request.getImgList();
+
+            if(imgList.isEmpty() || imgList.size() > 5) {
+                log.error("이미지는 1장 이상, 최대 5장까지 등록할 수 있습니다.");
+                return AttachResponse.UploadBucketResponse.builder()
+                        .code(String.valueOf(HttpStatus.BAD_REQUEST))
+                        .msg("이미지는 1장 이상, 최대 5장까지 등록할 수 있습니다.")
+                        .build();
+            }
+
+            List<String> result = new ArrayList<>();
+            for(MultipartFile img : imgList) {
+                log.info("[AttachServiceImpl] AWS S3 버킷에 업로드할 이미지 정보 - 이미지파일: {}", img);
+                String imgPath = awsS3Uploader.upload(img);
+                if(imgPath != null) {
+                    result.add(imgPath);
+                }
+            }
+
+            if(result.size() != imgList.size()) {
+                log.error("AWS S3 버킷에 등록된 이미지와 게시글 첨부 이미지로 등록을 요청한 이미지 개수가 다릅니다.");
+                return AttachResponse.UploadBucketResponse.builder()
+                        .code(String.valueOf(HttpStatus.OK))
+                        .msg("S3 버킷에 등록된 이미지의 개수가 등록을 요청한 이미지 개수와 다릅니다.")
+                        .build();
+            }
+
+            log.info("AWS S3 버킷에 {}장의 이미지를 정상적으로 등록했습니다.", result.size());
+            log.info("S3 버킷 등록 이미지 정보: {}",  result);
+
+            return AttachResponse.UploadBucketResponse.builder()
+                    .code(String.valueOf(HttpStatus.OK))
+                    .msg("정상적으로 AWS S3 버킷에 이미지 등록을 완료했습니다.")
+                    .data(result)
+                    .build();
+
+        } catch (Exception e) {
+            log.error("error: ", e);
+            return AttachResponse.UploadBucketResponse.builder()
+                    .code(String.valueOf(HttpStatus.INTERNAL_SERVER_ERROR))
+                    .msg("AWS S3 버킷에 이미지를 등록하던 중 문제가 발생했습니다.")
+                    .build();
+
+        }
+
+    }
+
+    /**
+     * uploadImages: S3 버킷에 저장된 이미지 객체 URL을 ATTACH 테이블에 저장하는 메서드
+     *
+     * @param request attachType, ids, imgList
+     * @return AttachResponse.UploadResponse
+     */
+    @Override
+    public AttachResponse.UploadResponse uploadImages(AttachRequest.UploadRequest request) {
+
+        try {
+
+            AttachType type = request.getAttachType();
+            Long id = request.getIds();
+            Map<Long, String> imgList = request.getImgList();
+            List<Attach> attachs = new ArrayList<>();
+
+            if(imgList.size() < 1 || imgList.size() > 5) {
+                log.error("이미지는 1장 이상, 최대 5장까지 등록할 수 있습니다.");
+                return AttachResponse.UploadResponse.builder()
+                        .code(String.valueOf(HttpStatus.BAD_REQUEST))
+                        .msg("이미지는 1장 이상, 최대 5장까지 등록할 수 있습니다.")
+                        .build();
+            }
+
+            for(long key : imgList.keySet()) {
+                log.info("[AttachServiceImpl] 업로드할 이미지 정보 - 이미지순서: {}, 이미지 URL: {}", key, imgList.get(key));
+                Attach attach = Attach.builder()
+                        .type(type)
+                        .ids(id)
+                        .seq(key)
+                        .imgPath(imgList.get(key))
+                        .build();
+                attachs.add(attach);
+            }
+
+            log.info("[AttachServiceImpl] DB에 이미지 객체 URL을 저장합니다.");
+            attachRepository.saveAll(attachs);
+
+            return AttachResponse.UploadResponse.builder()
+                    .code(String.valueOf(HttpStatus.OK))
+                    .msg("정상적으로 이미지 업로드를 완료했습니다.")
+                    .data(true)
+                    .build();
+
+        } catch (Exception e) {
+            log.error("error: ", e);
+            return AttachResponse.UploadResponse.builder()
+                    .code(String.valueOf(HttpStatus.INTERNAL_SERVER_ERROR))
+                    .msg("이미지를 업로드하던 중 문제가 발생했습니다.")
+                    .build();
+        }
+
+    }
+
+    /**
      * getBoardImages: 하나의 게시글에 등록된 이미지 목록(순서: 이미지URL)을 ATTACH 테이블에서 조회하는 메서드
+     * 2023.08.01 리턴 타입의 경우 attachId를 포함하여 반환하기 위해 Map<Long, String> 형식에서 Map<Long, Map<Long, String>> 형식으로 변경함.
      *
      * @param request type, id
      * @return AttachResponse.GetImageResponse
@@ -113,15 +223,26 @@ public class AttachServiceImpl implements AttachService {
 
             List<Attach> attachList = attachRepository.findAllByIds(id);
 
-            Map<Long, String> boardImageList = attachList.stream()
-                    .collect(Collectors.toMap(Attach::getSeq, Attach::getImgPath));
+//            Map<Long, String> boardImageList = attachList.stream()
+//                    .collect(Collectors.toMap(Attach::getSeq, Attach::getImgPath));
 
-            log.info("[AttachServiceImpl] 조회할 게시글의 이미지 목록: {}", boardImageList);
+            /**
+             * 게시글 번호로 조회한 ATTACH 데이터 목록을 파싱 한다.
+             * 파싱 형식: {attachId: {seq: imgPath}}
+             */
+            Map<Long, Map<Long, String>> result = new HashMap<>();
+            for(Attach attach : attachList) {
+                Map<Long, String> imgList = new HashMap<>();
+                imgList.put(attach.getSeq(), attach.getImgPath());
+                result.put(attach.getAttachId(), imgList);
+            }
+
+            log.info("[AttachServiceImpl] 조회할 게시글의 이미지 목록: {}", result);
 
             return AttachResponse.GetImageResponse.builder()
                     .code(String.valueOf(HttpStatus.OK))
                     .msg("정상적으로 해당 게시글의 등록된 이미지 목록을 조회하였습니다.")
-                    .data(boardImageList)
+                    .data(result)
                     .build();
 
         } catch (Exception e) {
@@ -170,6 +291,85 @@ public class AttachServiceImpl implements AttachService {
                     .build();
 
         }
+    }
+
+    /**
+     * updateImages: 하나의 게시글에 등록된 하나의 이미지를 수정하는 메서드
+     *
+     * @param request attachId, attachType, ids, imgList
+     * @return AttachResponse.UpdateResponse
+     */
+    @Override
+    public AttachResponse.UpdateResponse updateImage(AttachRequest.UpdateRequest request) {
+
+        try {
+            Long attachId = request.getAttachId();
+            String imgPath = request.getImgPath();
+
+            Optional<Attach> findAttach = attachRepository.findById(attachId);
+            Attach attach = findAttach.orElseThrow(IllegalArgumentException::new);
+
+            log.info("[AttachServiceImpl] 이미지 수정 - 기존 이미지 URL: {}", attach.getImgPath());
+
+            attach.changeImgPath(imgPath);
+            attachRepository.save(attach);
+
+            log.info("[AttachServiceImpl] 이미지 수정 - 수정 이미지 URL: {}", imgPath);
+
+            return AttachResponse.UpdateResponse.builder()
+                    .code(String.valueOf(HttpStatus.OK))
+                    .msg("정상적으로 게시글의 이미지를 수정했습니다.")
+                    .data(true)
+                    .build();
+
+        } catch (Exception e) {
+            log.error("error:", e);
+            return AttachResponse.UpdateResponse.builder()
+                    .code(String.valueOf(HttpStatus.INTERNAL_SERVER_ERROR))
+                    .msg("이미지를 수정하던 중 문제가 발생했습니다.")
+                    .build();
+        }
+
+    }
+
+    /**
+     * deleteImage: 하나의 게시글에 등록된 하나의 이미지를 삭제하는 메서드
+     *
+     * @param attachId
+     * @return AttachResponse.DeleteResponse
+     */
+    @Override
+    public AttachResponse.DeleteResponse deleteImage(Long attachId) {
+
+        try {
+
+            Optional<Attach> attach = attachRepository.findById(attachId);
+
+            if(attach.isPresent()) {
+                log.info("[AttachServiceImpl] 삭제할 이미지 첨부파일 번호(PK): {}", attachId);
+                attachRepository.deleteById(attachId);
+                return AttachResponse.DeleteResponse.builder()
+                        .code(String.valueOf(HttpStatus.OK))
+                        .msg("정상적으로 이미지를 삭제했습니다.")
+                        .data(true)
+                        .build();
+            }
+
+            log.error("[AttachServiceImpl] 존재하지 않는 이미지 URL 이기에 삭제할 수 없습니다.");
+            return AttachResponse.DeleteResponse.builder()
+                    .code(String.valueOf(HttpStatus.NOT_FOUND))
+                    .msg("이미지를 삭제하던 중 문제가 발생했습니다.")
+                    .build();
+
+        } catch (Exception e) {
+            log.error("error: ", e);
+            e.printStackTrace();
+            return AttachResponse.DeleteResponse.builder()
+                    .code(String.valueOf(HttpStatus.INTERNAL_SERVER_ERROR))
+                    .msg("이미지를 삭제하던 중 문제가 발생했습니다.")
+                    .build();
+        }
+
     }
 
 }


### PR DESCRIPTION
## 🤔 Motivation
- AWS S3 Bucket 이미지 등록 API와 DB 저장 API 분리
- 이미지 수정 API 개발
- 이미지 삭제 API 개발

<br>

## 💡 Key Changes
### API 분리
- 기존 AWS S3 버킷에 이미지를 등록하고 이미지 URL을 반환받아 DB에 저장하는 로직이 하나의 메서드에서 무겁게 동작하고 있었습니다.
- API 확장성을 고려하여 AWS S3 버킷 이미지를 등록하는 API와 ATTACH 테이블로 이미지 URL 문자열을 저장하는 API로 분리했습니다.

|분류|API 명|사용여부|
|:--:|:--:|:--:|
|기존|uploadImageDeprecated|❌|
|추가|uploadS3BucketImages|✅|
|추가|uploadImages|✅|

> uploadImageDeprecated라는 메서드는 기존 레거시 로직으로, AWS S3 버킷에 이미지를 등록하고 DB에 저장하는 개선 전 로직인데, deprecated를 메서드명에 명시해두었습니다. 바로 삭제해도 무방하나 코드 개선간 참고해야 할 부분이 있어 주석처리보단 메서드명 변경을 했으니 참고 부탁드립니다.

### 이미지 수정 및 삭제 API 개발
- 이미지 수정 API와 삭제 API 모두 단일 Attach 정보를 요청으로 받아 변경하고 삭제 처리를 하도록 구현했습니다.
- 그 중, 이미지 수정의 경우 이미지 목록 전체를 요청으로 받아 목록 순회를 통해 **변경점이 감지된 Attach만 수정하는 방식**을 고려해볼 예정입니다.
- 이미지 수정시 UI의 기본 기획 및 설계를 따라가야 하지만 화면 단 기획 및 설계가 미흡한 부분이 있기에 추후 수정이 필요할 수 있습니다.

### 테스트

<img width="795" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/59594946/3949c211-22e6-4489-94bc-1ca9ebad66eb">

- 테스트는 `AttachServiceImplTest` 테스트 클래스에서 진행했습니다.
- 이미지 등록 API 분리와 수정/삭제 API의 추가로 테스트 케이스가 추가되었습니다.

### 향후 개발일정
- Attach 도메인만의 전역 예외 처리 로직 추가
- 응답 객체 일반화 -> 현재 응답 DTO 클래스의 가독성 저하 및 중복 이슈 문제가 가장 큰 이유!
- 응답에 이용할 상태코드, 메시지 상수화 -> Enum 클래스를 활용하여 응답 객체로 내려줄 코드와 메시지를 관리할 예정!
- 미흡한 테스트코드 보완 -> 통합 테스트의 레드 케이스 추가 및 단위 테스트 코드를 고려할 예정!

### 추가 전달사항
> 이번 PR에 특정한 이슈대로 커밋을 여러 번 나누어야 했으나 개인 부주의로 커밋 세분화를 제대로 진행하지 못했습니다. 다음 PR부터 커밋내역을 상세히 분기화하는 코드 컨벤션을 꼭 지키도록 하겠습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @byeongJoo05 @hb9397 @IToriginal 

close #49
close #51 
close #57 
