### PR TITLE
[Feat/Refector] 예외 처리 기능 추가 및 Attach 도메인 비즈니스 로직 개선

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/attach/controller/AttachController.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/controller/AttachController.java
@@ -5,6 +5,7 @@ import com.kakao.saramaracommunity.attach.dto.response.AttachResponse;
 import com.kakao.saramaracommunity.attach.service.AttachService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,20 +22,6 @@ import org.springframework.web.bind.annotation.*;
 public class AttachController {
 
     private final AttachService attachService;
-
-    /**
-     * uploadImageDeprecated: 이미지 업로드 API
-     * URL: POST /api/v1/attach/upload
-     * 1장 이상, 최대 5장까지의 이미지를 S3와 MariaDB에 업로드한다.
-     *
-     * @param request type, id, imgList
-     * @return AttachResponse.UploadResponse
-     */
-    @PostMapping("/upload/deprecated")
-    public ResponseEntity<AttachResponse.UploadResponse> uploadImageDeprecated(@RequestBody @Valid AttachRequest.UploadRequestDeprecated request) {
-        AttachResponse.UploadResponse response = attachService.uploadImageDeprecated(request);
-        return ResponseEntity.ok().body(response);
-    }
 
     /**
      * uploadS3BucketImages: AWS S3 Bucket 이미지 파일 등록 API
@@ -111,7 +98,7 @@ public class AttachController {
     @DeleteMapping("/board")
     public ResponseEntity<AttachResponse.DeleteResponse> deleteImage(@Valid @PathVariable Long attachId) {
         AttachResponse.DeleteResponse response = attachService.deleteImage(attachId);
-        return ResponseEntity.ok().body(response);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(response);
     }
 
 

--- a/src/main/java/com/kakao/saramaracommunity/attach/controller/AttachControllerAdvice.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/controller/AttachControllerAdvice.java
@@ -1,0 +1,75 @@
+package com.kakao.saramaracommunity.attach.controller;
+
+import com.kakao.saramaracommunity.attach.exception.AttachNotFoundException;
+import com.kakao.saramaracommunity.attach.exception.ImageUploadOutOfRangeException;
+import com.kakao.saramaracommunity.common.dto.Payload;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * AttachControllerAdvice: Attach(첨부 이미지) 관련 예외를 처리할 클래스
+ * 가장 높은 우선순위로 예외를 핸들링합니다.
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+@Log4j2
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class AttachControllerAdvice {
+
+    /**
+     * 업로드한 이미지의 개수가 정한 범위를 벗어났을 경우 발생하는 예외를 핸들링하는 메서드입니다.
+     * 이미지 개수 범위는 0.0.1 버전 기준 1장부터 5장까지입니다.
+     *
+     * @param exception 이미지 개수 범위를 벗어났을 경우
+     * @return Status 코드와 예외 메시지 반환
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(ImageUploadOutOfRangeException.class)
+    public ResponseEntity<Payload> handleImageUploadOutOfRange(ImageUploadOutOfRangeException exception) {
+
+        log.error("[ImageUploadOutOfRangeException]");
+
+        return ResponseEntity
+                .status(exception.getStatusWithCode().getHttpStatus())
+                .body(
+                        Payload.errorPayload(
+                            exception.getStatusWithCode().getHttpStatus().value(),
+                            exception.getStatusWithCode().getMessage()
+                        )
+                );
+    }
+
+    /**
+     * 원하는 이미지를 찾지 못했을 때 발생하는 예외를 핸들링하는 메서드입니다.
+     *
+     * @param exception 이미지를 찾지 못했을 경우
+     * @return Status 코드와 예외 메시지 반환
+     */
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(AttachNotFoundException.class)
+    public ResponseEntity<Payload> handleAttachNotFound(AttachNotFoundException exception) {
+
+        log.error("[AttachNotFoundException]");
+
+        return ResponseEntity
+                .status(exception.getStatusWithCode().getHttpStatus())
+                .body(
+                        Payload.errorPayload(
+                                exception.getStatusWithCode().getHttpStatus().value(),
+                                exception.getStatusWithCode().getMessage()
+                        )
+                );
+    }
+
+
+
+
+}

--- a/src/main/java/com/kakao/saramaracommunity/attach/dto/request/AttachRequest.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/dto/request/AttachRequest.java
@@ -36,6 +36,7 @@ public class AttachRequest {
         @NotNull(message = "게시글이나 댓글의 번호값을 알 수 없습니다.")
         private Long ids;
 
+        @NotNull(message = "이미지 목록이 비어있습니다.")
         private Map<Long, MultipartFile> imgList;
 
         @Builder
@@ -63,6 +64,7 @@ public class AttachRequest {
         @NotNull(message = "게시글이나 댓글의 번호값을 알 수 없습니다.")
         private Long ids;
 
+        @NotNull(message = "이미지 목록이 비어있습니다.")
         private Map<Long, String> imgList;
 
         @Builder
@@ -81,6 +83,7 @@ public class AttachRequest {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @Getter
     public static class UploadBucketRequest {
+        @NotNull(message = "이미지 목록이 비어있습니다.")
         private List<MultipartFile> imgList;
 
         @Builder

--- a/src/main/java/com/kakao/saramaracommunity/attach/dto/response/AttachResponse.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/dto/response/AttachResponse.java
@@ -19,14 +19,14 @@ public class AttachResponse {
     @Getter
     public static class UploadResponse {
 
-        private String code;
+        private Integer code;
 
         private String msg;
 
         private boolean data;
 
         @Builder
-        private UploadResponse(String code, String msg, boolean data) {
+        private UploadResponse(Integer code, String msg, boolean data) {
             this.code = code;
             this.msg = msg;
             this.data = data;
@@ -37,14 +37,14 @@ public class AttachResponse {
     @Getter
     public static class UploadBucketResponse {
 
-        private String code;
+        private Integer code;
 
         private String msg;
 
         private List<String> data;
 
         @Builder
-        private UploadBucketResponse(String code, String msg, List<String> data) {
+        private UploadBucketResponse(Integer code, String msg, List<String> data) {
             this.code = code;
             this.msg = msg;
             this.data = data;
@@ -55,14 +55,14 @@ public class AttachResponse {
     @Getter
     public static class GetImageResponse {
 
-        private String code;
+        private Integer code;
 
         private String msg;
 
         private Map<Long, Map<Long, String>> data;
 
         @Builder
-        private GetImageResponse(String code, String msg, Map<Long, Map<Long, String>> data) {
+        private GetImageResponse(Integer code, String msg, Map<Long, Map<Long, String>> data) {
             this.code = code;
             this.msg = msg;
             this.data = data;
@@ -73,14 +73,14 @@ public class AttachResponse {
     @Getter
     public static class GetAllImageResponse {
 
-        private String code;
+        private Integer code;
 
         private String msg;
 
         private Map<Long, Map<Long, String>> data;
 
         @Builder
-        private GetAllImageResponse(String code, String msg, Map<Long, Map<Long, String>> data) {
+        private GetAllImageResponse(Integer code, String msg, Map<Long, Map<Long, String>> data) {
             this.code = code;
             this.msg = msg;
             this.data = data;
@@ -91,14 +91,14 @@ public class AttachResponse {
     @Getter
     public static class UpdateResponse {
 
-        private String code;
+        private Integer code;
 
         private String msg;
 
         private boolean data;
 
         @Builder
-        private UpdateResponse(String code, String msg, boolean data) {
+        private UpdateResponse(Integer code, String msg, boolean data) {
             this.code = code;
             this.msg = msg;
             this.data = data;
@@ -108,14 +108,14 @@ public class AttachResponse {
     @Getter
     public static class DeleteResponse {
 
-        private String code;
+        private Integer code;
 
         private String msg;
 
         private boolean data;
 
         @Builder
-        private DeleteResponse(String code, String msg, boolean data) {
+        private DeleteResponse(Integer code, String msg, boolean data) {
             this.code = code;
             this.msg = msg;
             this.data = data;

--- a/src/main/java/com/kakao/saramaracommunity/attach/exception/AttachErrorCode.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/exception/AttachErrorCode.java
@@ -1,0 +1,44 @@
+package com.kakao.saramaracommunity.attach.exception;
+
+import com.kakao.saramaracommunity.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * AttachRequest: Attach(첨부 이미지) 관련 요청 DTO를 관리하는 클래스
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+@RequiredArgsConstructor
+@Getter
+public enum AttachErrorCode implements ErrorCode {
+
+    /**
+     * Attach Code
+     * ATTACH_IMAGE_LIMIT: 업로드할 수 있는 이미지 개수의 범위를 벗어날 경우 400 에러코드를 반환
+     * ATTACH_INSERT_FAILED: ATTACH 테이블에 데이터를 저장할 때 문제가 발생할 경우 400 에러코드를 반환
+     * ATTACH_UPDATE_FAILED: ATTACH 테이블에 데이터를 수정할 때 문제가 발생할 경우 400 에러코드를 반환
+     * ATTACH_DELETE_FAILED: ATTACH 테이블에 데이터를 삭제할 때 문제가 발생할 경우 400 에러코드를 반환
+     * ATTACH_NOT_FOUND: ATTACH 객체가 비어있을 경우 404 에러코드를 반환
+     * ATTACH_AWS_S3_UPLOAD_FAILED: AWS S3 Bucket으로 업로드를 실패할 경우 500 에러코드를 반환
+     */
+    ATTACH_IMAGE_RANGE_OUT(HttpStatus.BAD_REQUEST, "이미지는 최소 1장 이상, 최대 5장까지 등록할 수 있습니다."),
+
+    ATTACH_INSERT_FAILED(HttpStatus.BAD_REQUEST, "DB에 데이터를 저장할 때 문제가 발생했습니다."),
+
+    ATTACH_UPDATE_FAILED(HttpStatus.BAD_REQUEST, "DB에 데이터를 수정할 때 문제가 발생했습니다."),
+
+    ATTACH_DELETE_FAILED(HttpStatus.BAD_REQUEST, "DB에 데이터를 삭제할 때 문제가 발생했습니다."),
+
+    ATTACH_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이미지(데이터)를 찾을 수 없습니다."),
+
+    ATTACH_AWS_S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AWS S3 버킷으로 이미지를 업로드하던 중 문제가 발생했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+}

--- a/src/main/java/com/kakao/saramaracommunity/attach/exception/AttachNotFoundException.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/exception/AttachNotFoundException.java
@@ -1,0 +1,22 @@
+package com.kakao.saramaracommunity.attach.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * AttachNotFoundException: Attach(첨부 이미지)를 찾지 못할 경우 발생시킬 예외 클래스
+ * Unchecked Exception(RuntimeException)을 상속받기에 예외가 발생하면 롤백을 수행합니다.
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+@Getter
+public class AttachNotFoundException extends RuntimeException {
+
+    private final AttachErrorCode statusWithCode;
+
+    public AttachNotFoundException(AttachErrorCode statusWithCode) {
+        super(statusWithCode.getMessage());
+        this.statusWithCode = statusWithCode;
+    }
+}

--- a/src/main/java/com/kakao/saramaracommunity/attach/exception/ImageUploadOutOfRangeException.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/exception/ImageUploadOutOfRangeException.java
@@ -1,0 +1,25 @@
+package com.kakao.saramaracommunity.attach.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * ImageUploadOutOfRangeException: Attach(첨부 이미지)의 업로드 개수 범위가 아닐 경우 발생시킬 예외 클래스
+ * 이미지는 1장 ~ 5장까지만 업로드할 수 있습니다.
+ * Unchecked Exception(RuntimeException)을 상속받기에 예외가 발생하면 롤백을 수행합니다.
+ * 해당 예외 메시지를 상위 클래스인 RuntimeException의 메시지로 설정합니다.
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+@Getter
+public class ImageUploadOutOfRangeException extends RuntimeException {
+
+    private final AttachErrorCode statusWithCode;
+
+    public ImageUploadOutOfRangeException(AttachErrorCode statusWithCode) {
+        super(statusWithCode.getMessage());
+        this.statusWithCode = statusWithCode;
+    }
+}

--- a/src/main/java/com/kakao/saramaracommunity/attach/service/AttachService.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/service/AttachService.java
@@ -3,6 +3,7 @@ package com.kakao.saramaracommunity.attach.service;
 
 import com.kakao.saramaracommunity.attach.dto.request.AttachRequest;
 import com.kakao.saramaracommunity.attach.dto.response.AttachResponse;
+import com.kakao.saramaracommunity.common.dto.Payload;
 
 /**
  * AttachService: 이미지 첨부파일 관련 비즈니스 로직을 수행할 서비스 인터페이스
@@ -11,8 +12,6 @@ import com.kakao.saramaracommunity.attach.dto.response.AttachResponse;
  * @version 0.0.1
  */
 public interface AttachService {
-
-    AttachResponse.UploadResponse uploadImageDeprecated(AttachRequest.UploadRequestDeprecated request);
 
     AttachResponse.UploadBucketResponse uploadS3BucketImages(AttachRequest.UploadBucketRequest request);
 

--- a/src/main/java/com/kakao/saramaracommunity/comment/controller/CommentControllerAdvice.java
+++ b/src/main/java/com/kakao/saramaracommunity/comment/controller/CommentControllerAdvice.java
@@ -1,11 +1,8 @@
 package com.kakao.saramaracommunity.comment.controller;
 
-import com.kakao.saramaracommunity.comment.exception.CommentErrorCode;
 import com.kakao.saramaracommunity.comment.exception.CommentNotFoundException;
 import com.kakao.saramaracommunity.common.dto.Payload;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -15,16 +12,18 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
  */
 @RestControllerAdvice
 @Log4j2
-public class CommentExceptionHandler {
+public class CommentControllerAdvice {
 
     @ExceptionHandler(CommentNotFoundException.class)
     public ResponseEntity<Payload> handleCommentNotFoundException(CommentNotFoundException e) {
 
-        Payload payload = Payload.errorPayload(
-                e.getCommentErrorCode().getHttpStatus(),
-                e.getCommentErrorCode().getMessage()
-        );
-
-        return ResponseEntity.status(e.getCommentErrorCode().getHttpStatus()).body(payload);
+        return ResponseEntity
+                .status(e.getCommentErrorCode().getHttpStatus())
+                .body(
+                        Payload.errorPayload(
+                                e.getCommentErrorCode().getHttpStatus().value(),
+                                e.getCommentErrorCode().getMessage()
+                        )
+                );
     }
 }

--- a/src/main/java/com/kakao/saramaracommunity/comment/exception/CommentErrorCode.java
+++ b/src/main/java/com/kakao/saramaracommunity/comment/exception/CommentErrorCode.java
@@ -1,18 +1,18 @@
 package com.kakao.saramaracommunity.comment.exception;
 
-import com.kakao.saramaracommunity.common.exception.CommonErrorCode;
-import lombok.AllArgsConstructor;
+import com.kakao.saramaracommunity.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 @Getter
-public enum CommentErrorCode implements CommonErrorCode {
+public enum CommentErrorCode implements ErrorCode {
 
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "댓글을 찾을 수 없습니다.");
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다.");
 
-    private final Integer httpStatus;
+    private final HttpStatus httpStatus;
+
     private final String message;
 
 }

--- a/src/main/java/com/kakao/saramaracommunity/common/dto/Payload.java
+++ b/src/main/java/com/kakao/saramaracommunity/common/dto/Payload.java
@@ -1,30 +1,30 @@
 package com.kakao.saramaracommunity.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.kakao.saramaracommunity.comment.exception.CommentErrorCode;
-import com.kakao.saramaracommunity.common.exception.CommonErrorCode;
 import lombok.*;
 import org.springframework.http.HttpStatus;
 
 /**
  * 공통 ResponseDTO로 사용할 Payload 클래스입니다.
- *
  * 응답데이터로 줄 때 null이 발생하는 것들은 응답데이터로 던지지 못하도록 @JsonInclude를 사용하였습니다.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Data
+@Getter
 @Builder
 public class Payload<T> {
+
     private Integer status;
-    private T data;
+
     private String message;
+
+    private T data;
 
     /**
      * exceptionHandler에 응답 데이터로 사용할 errorPayload 메서드입니다.
      *
      * @param status - 상태값
-     * @param message - 오류메세지
-     * @return
+     * @param message - 오류 메세지
+     * @return Payload
      */
     public static <T>Payload<T> errorPayload(final Integer status, final String message) {
 
@@ -35,19 +35,19 @@ public class Payload<T> {
     }
 
     /**
-     * Controller에 응답 데이터로 사용할 errorPayload 메서드입니다.
+     * Controller에 응답 데이터로 사용할 successPayload 메서드입니다.
      *
      * @param status - 상태값
-     * @param data - 던져줄 데이터
      * @param message - 사용에 따라 다름
-     * @return
+     * @param data - 던져줄 데이터
+     * @return Payload
      */
-    public static <T>Payload<T> successPayload(final Integer status, final T data, final String message) {
+    public static <T>Payload<T> successPayload(final Integer status, final String message, final T data) {
 
         return Payload.<T>builder()
                 .status(status)
-                .data(data)
                 .message(message)
+                .data(data)
                 .build();
     }
 }

--- a/src/main/java/com/kakao/saramaracommunity/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/kakao/saramaracommunity/common/exception/CommonErrorCode.java
@@ -1,15 +1,33 @@
 package com.kakao.saramaracommunity.common.exception;
 
-
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 /**
- * 다른 패키지에서도 사용할 수 있게 인터페이스타입으로 작성한 ErrorCode입니다.
+ * AttachRequest: Attach(첨부 이미지) 관련 요청 DTO를 관리하는 클래스
+ *
+ * @author Taejun
+ * @version 0.0.1
  */
-public interface CommonErrorCode {
-    String name();
+@RequiredArgsConstructor
+@Getter
+public enum CommonErrorCode implements ErrorCode {
 
-    Integer getHttpStatus();
+    /**
+     * 전역으로 내려줄 HttpStatus Code와 메시지입니다.
+     * 400, 401, 403, 404, 405, 500
+     */
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    UNAUTHORIZED_REQUEST(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자의 요청입니다."),
+    FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "권한이 없는 사용자의 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메서드가 호출되었습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버에서 문제가 발생했습니다."),
+    ;
 
-    String getMessage();
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
 }

--- a/src/main/java/com/kakao/saramaracommunity/common/exception/ErrorCode.java
+++ b/src/main/java/com/kakao/saramaracommunity/common/exception/ErrorCode.java
@@ -1,0 +1,17 @@
+package com.kakao.saramaracommunity.common.exception;
+
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * 다른 패키지에서도 사용할 수 있게 인터페이스타입으로 작성한 ErrorCode입니다.
+ */
+public interface ErrorCode {
+
+    String name();
+
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+
+}

--- a/src/main/java/com/kakao/saramaracommunity/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakao/saramaracommunity/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,110 @@
+package com.kakao.saramaracommunity.common.exception;
+
+import com.kakao.saramaracommunity.common.dto.Payload;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+/**
+ * GlobalExceptionHandler: 도메인과 관련된 예외가 아닌 나머지 예외를 핸들링하는 클래스입니다.
+ * 기본적인 예외를 처리하기 위해 ResponseEntityExceptionHandler를 상속 받습니다.
+ * 400(유효성 검사), 404, 500 에러에 대한 예외를 핸들링합니다.
+ * 가장 낮은 우선순위로 예외를 핸들링합니다.
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+@RestControllerAdvice
+@Order
+@Log4j2
+public class GlobalExceptionHandler {
+
+    /**
+     * 유효성 검사를 진행할 @Valid 어노테이션이 붙은 요청 DTO 클래스에서 유효성 검사가 실패할 경우 발생하는 예외를 핸들링하는 메서드입니다.
+     * 메시지의 경우 유효성 검사 결과 객체에서 필드 오류 정보를 찾은 후, 해당 예외의 기본 메시지를 추출하여 문자열로 반환합니다.
+     *
+     * @param exception 유효성 검증 실패 시 던지는 예외
+     * @return 예외 메세지와 응답 코드를 리턴
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<Payload> handleMethodArgumentNotValidException (
+            MethodArgumentNotValidException exception,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request
+    ) {
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(
+                        Payload.errorPayload(
+                                HttpStatus.BAD_REQUEST.value(),
+                                exception.getBindingResult().getFieldErrors()
+                                        .stream()
+                                        .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                                        .toList().toString()
+                        )
+                );
+
+    }
+
+    /**
+     * 서버에서 요청한 리소스를 찾을 수 없는 예외를 핸들링하는 메서드입니다.
+     *
+     * @param exception 요청에 대한 리소르를 찾지 못할 경우 던지는 예외
+     * @return 예외 메세지와 응답 코드를 리턴
+     */
+    @ExceptionHandler(NoHandlerFoundException.class)
+    protected ResponseEntity<Payload> handleNotFoundException (
+            NoHandlerFoundException exception
+    ) {
+
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(
+                        Payload.errorPayload(
+                                HttpStatus.NOT_FOUND.value(),
+                                exception.getMessage()
+                        )
+                );
+
+    }
+
+    /**
+     * 서버 내부에서 문제 발생시 예외를 핸들링하는 메서드입니다.
+     * 어떤 문제인지 파악하기 쉽도록 request의 일부와 exception 스택 트레이스 로그를 출력합니다.
+     *
+     * @param exception 서버 문제 발생시 던지는 예외
+     * @return 예외 메세지와 응답 코드를 리턴
+     */
+    @ExceptionHandler({Exception.class})
+    protected ResponseEntity<Payload> handleException (
+            Exception exception,
+            HttpServletRequest request
+    ) {
+
+        log.error("[ERROR] 서버 내부에서 문제가 발생했습니다. method: {}, requestURI: {}, msg: {}", request.getMethod(), request.getRequestURI(), exception.getMessage());
+        log.error("{}", (Object) exception.getStackTrace());
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(
+                        Payload.errorPayload(
+                                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                                exception.getMessage()
+                        )
+                );
+
+    }
+
+}

--- a/src/main/java/com/kakao/saramaracommunity/member/dto/MemberErrorCode.java
+++ b/src/main/java/com/kakao/saramaracommunity/member/dto/MemberErrorCode.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public enum ErrorCode {
+public enum MemberErrorCode {
 	INVALID_INPUT_VALUE(400, "COMMON-001", "유효성 검증에 실패한 경우(Client 의 잘못된 요청)."),
 	INTERNAL_SERVER_ERROR(500, "COMMON-002", "서버에서 처리할 수 없는 경우."),
 

--- a/src/main/java/com/kakao/saramaracommunity/member/dto/MemberResDto.java
+++ b/src/main/java/com/kakao/saramaracommunity/member/dto/MemberResDto.java
@@ -14,5 +14,5 @@ import lombok.Setter;
 public class MemberResDto<T> {
 	boolean success;
 	T data;
-	ErrorCode errorCode;
+	MemberErrorCode memberErrorCode;
 }

--- a/src/main/java/com/kakao/saramaracommunity/member/exception/MemberControllerAdvice.java
+++ b/src/main/java/com/kakao/saramaracommunity/member/exception/MemberControllerAdvice.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.kakao.saramaracommunity.member.dto.MemberResDto;
-import com.kakao.saramaracommunity.member.dto.ErrorCode;
+import com.kakao.saramaracommunity.member.dto.MemberErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 /*
@@ -37,7 +37,7 @@ public class MemberControllerAdvice {
 
 		MemberResDto response = MemberResDto.builder()
 			.success(false)
-			.errorCode(ErrorCode.INTERNAL_SERVER_ERROR)
+			.memberErrorCode(MemberErrorCode.INTERNAL_SERVER_ERROR)
 			.build();
 		HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
 
@@ -56,7 +56,7 @@ public class MemberControllerAdvice {
 
 				// response 는 MemberResDto로 해당 클래스의 status는 ErrorCode 클래스의 정의된 status를 의미하며 이를 Getter 로 가져와서
 				// ErrorCode에 정의된 getHttpStatus() 메서드로 response(현재 Exception에 상응하는 HttpStatus를 가져온다.
-				status = response.getErrorCode().getHttpStatus();
+				status = response.getMemberErrorCode().getHttpStatus();
 
 				// 결과에 에러 필드 알려주기~
 				response.setData(fieldError.getField());
@@ -69,7 +69,7 @@ public class MemberControllerAdvice {
 				|| fieldError.getField().equals("changedPassword") || fieldError.getField().equals("changedPasswordCheck")) {
 
 				response = validExceptionHandlingMethod.passwordValidExceptionHandling(fieldErrorCode);
-				status = response.getErrorCode().getHttpStatus();
+				status = response.getMemberErrorCode().getHttpStatus();
 				response.setData(fieldError.getField());
 				log.error(fieldError.getField());
 
@@ -78,7 +78,7 @@ public class MemberControllerAdvice {
 			// @Valid Exception 의 필드가 닉네임인 경우
 			else if (fieldError.getField().equals("nickname")) {
 				response = validExceptionHandlingMethod.nicknameValidExceptionHandling(fieldErrorCode);
-				status = response.getErrorCode().getHttpStatus();
+				status = response.getMemberErrorCode().getHttpStatus();
 				response.setData(fieldError.getField());
 				log.error(fieldError.getField());
 

--- a/src/main/java/com/kakao/saramaracommunity/member/exception/MemberControllerAdvice.java
+++ b/src/main/java/com/kakao/saramaracommunity/member/exception/MemberControllerAdvice.java
@@ -21,7 +21,7 @@ Exception에 대한 결과를 ErrorCode 클래스를 이용해서 MemberResDto�
 @Log4j2
 @RequiredArgsConstructor
 @RestControllerAdvice
-public class GlobalExceptionHandler {
+public class MemberControllerAdvice {
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<MemberResDto> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
 

--- a/src/main/java/com/kakao/saramaracommunity/member/exception/ValidExceptionHandlingMethod.java
+++ b/src/main/java/com/kakao/saramaracommunity/member/exception/ValidExceptionHandlingMethod.java
@@ -3,7 +3,7 @@ package com.kakao.saramaracommunity.member.exception;
 
 import org.springframework.validation.FieldError;
 
-import com.kakao.saramaracommunity.member.dto.ErrorCode;
+import com.kakao.saramaracommunity.member.dto.MemberErrorCode;
 import com.kakao.saramaracommunity.member.dto.MemberResDto;
 
 import lombok.RequiredArgsConstructor;
@@ -14,7 +14,7 @@ import lombok.extern.log4j.Log4j2;
 public class ValidExceptionHandlingMethod {
 
 	// ErrorCode 기본값 초기화
-	ErrorCode errorCode;
+	MemberErrorCode memberErrorCode;
 	String errorMessage;
 
 	/*
@@ -32,11 +32,11 @@ public class ValidExceptionHandlingMethod {
 	// Email 의 최대, 최소 길이를 @Size로 설정해서 @Size에 대한 Exception은 ErrorCode에 정의하지 않아서 기본 Message로 지정한 값으로 대체하기 위해서
 	// fieldError 를 받아온다.
 	public MemberResDto emailValidExceptionHandling(FieldError fieldError, String fieldErrorCode){
-			errorCode = ErrorCode.INVALID_INPUT_EMAIL;
+			memberErrorCode = MemberErrorCode.INVALID_INPUT_EMAIL;
 
 			// @NotNull, @NotBlank 에 대한 Exception
 			if (fieldErrorCode.equals("NotNull") || fieldErrorCode.equals("NotBlank")) {
-				errorMessage = ErrorCode.INVALID_INPUT_EMAIL.getDescription();
+				errorMessage = MemberErrorCode.INVALID_INPUT_EMAIL.getDescription();
 			}
 			// @Size에 대한 Exception
 			else if (fieldErrorCode.equals("Size")) {
@@ -44,64 +44,64 @@ public class ValidExceptionHandlingMethod {
 			}
 			// Email 형식이 올바른지 검증하는 것에 대한 Exception
 			else if (fieldErrorCode.equals("Pattern")) {
-				errorMessage = ErrorCode.INVALID_INPUT_EMAIL.getDescription();
+				errorMessage = MemberErrorCode.INVALID_INPUT_EMAIL.getDescription();
 			}
 			// 그외 알 수 없는 경우의 Exception 처리
 			else {
-				errorMessage = ErrorCode.INTERNAL_SERVER_ERROR.getDescription();
+				errorMessage = MemberErrorCode.INTERNAL_SERVER_ERROR.getDescription();
 			}
 			MemberResDto response = MemberResDto.builder()
 				.success(false)
 				.data(errorMessage)
-				.errorCode(errorCode)
+				.memberErrorCode(memberErrorCode)
 				.build();
 			return response;
 	}
 
 	// Password @Valid 유효성 검사 실패한 경우에 발생할 수 있는 Exception 을 다루는 메서드
 	public MemberResDto passwordValidExceptionHandling(String fieldErrorCode){
-		errorCode = ErrorCode.INVALID_INPUT_PW;
+		memberErrorCode = MemberErrorCode.INVALID_INPUT_PW;
 
 		// @NotNull, @NotBlank 에 대한 Exception
 		if (fieldErrorCode.equals("NotNull") || fieldErrorCode.equals("NotBlank")) {
-			errorMessage = ErrorCode.INVALID_INPUT_PW.getDescription();
+			errorMessage = MemberErrorCode.INVALID_INPUT_PW.getDescription();
 		}
 		// 올바른 비밀번호 형식 @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}") 를 통과하지 못한 경우
 		 else if (fieldErrorCode.equals("Pattern")) {
-			errorMessage = ErrorCode.INVALID_INPUT_PW.getDescription();
+			errorMessage = MemberErrorCode.INVALID_INPUT_PW.getDescription();
 		}
 		// 그외 알 수 없는 경우의 Exception 처리
 		 else {
-			errorMessage = ErrorCode.INTERNAL_SERVER_ERROR.getDescription();
+			errorMessage = MemberErrorCode.INTERNAL_SERVER_ERROR.getDescription();
 		}
 		MemberResDto response = MemberResDto.builder()
 			.success(false)
 			.data(errorMessage)
-			.errorCode(errorCode)
+			.memberErrorCode(memberErrorCode)
 			.build();
 		return response;
 	}
 
 	// Nickname @Valid 유효성 검사 실패한 경우에 발생할 수 있는 Exception 을 다루는 메서드
 	public MemberResDto nicknameValidExceptionHandling(String fieldErrorCode){
-		errorCode = ErrorCode.INVALID_INPUT_NICKNAME;
+		memberErrorCode = MemberErrorCode.INVALID_INPUT_NICKNAME;
 
 		// @NotNull, @NotBlank 에 대한 Exception
 		if (fieldErrorCode.equals("NotNull") || fieldErrorCode.equals("NotBlank")) {
-			errorMessage = ErrorCode.INVALID_INPUT_NICKNAME.getDescription();
+			errorMessage = MemberErrorCode.INVALID_INPUT_NICKNAME.getDescription();
 		}
 		// 올바른 닉네임 형식 @Pattern(regexp = "^[ㄱ-ㅎ가-힣A-Za-z0-9-_]{2,10}$")
 		else if (fieldErrorCode.equals("Pattern")) {
-			errorMessage = ErrorCode.INVALID_INPUT_NICKNAME.getDescription();
+			errorMessage = MemberErrorCode.INVALID_INPUT_NICKNAME.getDescription();
 		}
 		// 그외 알 수 없는 경우의 Exception 처리
 		else {
-			errorMessage = ErrorCode.INTERNAL_SERVER_ERROR.getDescription();
+			errorMessage = MemberErrorCode.INTERNAL_SERVER_ERROR.getDescription();
 		}
 		MemberResDto response = MemberResDto.builder()
 			.success(false)
 			.data(errorMessage)
-			.errorCode(errorCode)
+			.memberErrorCode(memberErrorCode)
 			.build();
 		return response;
 	}

--- a/src/main/java/com/kakao/saramaracommunity/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/member/service/MemberServiceImpl.java
@@ -8,7 +8,7 @@ import com.kakao.saramaracommunity.member.dto.MemberImageDto;
 import com.kakao.saramaracommunity.member.dto.MemberInfoResDto;
 import com.kakao.saramaracommunity.member.dto.MemberResDto;
 import com.kakao.saramaracommunity.member.dto.SignUpDto;
-import com.kakao.saramaracommunity.member.dto.ErrorCode;
+import com.kakao.saramaracommunity.member.dto.MemberErrorCode;
 import com.kakao.saramaracommunity.member.entity.Member;
 import com.kakao.saramaracommunity.member.entity.MemberImage;
 import com.kakao.saramaracommunity.member.entity.Role;
@@ -143,7 +143,7 @@ public class MemberServiceImpl implements MemberSerivce {
             if(!checkedCurrentPw){
                 MemberResDto response = MemberResDto.builder()
                     .success(false)
-                    .errorCode(ErrorCode.NOT_EQUALS_INPUT_CURRENT_PW)
+                    .memberErrorCode(MemberErrorCode.NOT_EQUALS_INPUT_CURRENT_PW)
                     .build();
                 return response;
             }
@@ -155,7 +155,7 @@ public class MemberServiceImpl implements MemberSerivce {
             if(!checkedChangedPw){
                 MemberResDto response = MemberResDto.builder()
                     .success(false)
-                    .errorCode(ErrorCode.NOT_EQUALS_INPUT_CHANGED_PW)
+                    .memberErrorCode(MemberErrorCode.NOT_EQUALS_INPUT_CHANGED_PW)
                     .build();
                 return response;
             }
@@ -209,7 +209,7 @@ public class MemberServiceImpl implements MemberSerivce {
                 if(maxCnt == 10){
                     MemberResDto response = MemberResDto.builder()
                         .success(false)
-                        .errorCode(ErrorCode.INTERNAL_SERVER_ERROR)
+                        .memberErrorCode(MemberErrorCode.INTERNAL_SERVER_ERROR)
                         .build();
 
                     return response;

--- a/src/main/java/com/kakao/saramaracommunity/member/service/MemberServiceMethod.java
+++ b/src/main/java/com/kakao/saramaracommunity/member/service/MemberServiceMethod.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import com.kakao.saramaracommunity.member.dto.ErrorCode;
+import com.kakao.saramaracommunity.member.dto.MemberErrorCode;
 import com.kakao.saramaracommunity.member.dto.MemberResDto;
 
 import lombok.RequiredArgsConstructor;
@@ -35,7 +35,7 @@ public class MemberServiceMethod {
 
 		MemberResDto result = MemberResDto.builder()
 			.success(false)
-			.errorCode(ErrorCode.DUPLICATE_EMAIL)
+			.memberErrorCode(MemberErrorCode.DUPLICATE_EMAIL)
 			.build();
 		return result;
 	}
@@ -72,7 +72,7 @@ public class MemberServiceMethod {
 	public MemberResDto makeDuplicatedNicknameResult(){
 		MemberResDto result = MemberResDto.builder()
 			.success(false)
-			.errorCode(ErrorCode.DUPLICATE_NICKNAME)
+			.memberErrorCode(MemberErrorCode.DUPLICATE_NICKNAME)
 			.build();
 		return result;
 	}
@@ -101,7 +101,7 @@ public class MemberServiceMethod {
 	public HttpStatus changeStatus(MemberResDto memberResDto) {
 		try {
 			if (!memberResDto.isSuccess()){
-				return memberResDto.getErrorCode().getHttpStatus();
+				return memberResDto.getMemberErrorCode().getHttpStatus();
 			}
 			return HttpStatus.OK;
 		} catch (Exception e){
@@ -117,7 +117,7 @@ public class MemberServiceMethod {
 
 		MemberResDto internalServerResult = MemberResDto.builder()
 			.success(false)
-			.errorCode(ErrorCode.INTERNAL_SERVER_ERROR)
+			.memberErrorCode(MemberErrorCode.INTERNAL_SERVER_ERROR)
 			.build();
 
 		return internalServerResult;

--- a/src/main/java/com/kakao/saramaracommunity/member/service/SignUpCheckingServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/member/service/SignUpCheckingServiceImpl.java
@@ -2,7 +2,6 @@ package com.kakao.saramaracommunity.member.service;
 
 import org.springframework.stereotype.Service;
 
-import com.kakao.saramaracommunity.member.dto.ErrorCode;
 import com.kakao.saramaracommunity.member.dto.MemberResDto;
 import com.kakao.saramaracommunity.member.repository.MemberRepository;
 

--- a/src/main/java/com/kakao/saramaracommunity/util/AwsS3Uploader.java
+++ b/src/main/java/com/kakao/saramaracommunity/util/AwsS3Uploader.java
@@ -29,8 +29,10 @@ public class AwsS3Uploader {
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 
-    public String upload(MultipartFile file) throws IOException {
+    public String upload(MultipartFile file) {
+
         boolean result = validateFileExists(file);
+
         if(!result) {
             log.info("[AwsS3Uploader] 업로드할 파일이 존재하지 않습니다.");
             return null;


### PR DESCRIPTION
# 🤔 Motivation
- 예외 처리 기능 추가 
- Attach 도메인 관련 비즈니스 로직 개선

<br>

# 💡 Key Changes

## 🛠️ 예외 처리 기능 추가

### 1. 전역 예외 처리 기능 추가
아래 예외에 대한 처리를 할 수 있도록 GlobalExceptionHanlder 클래스를 작성하였습니다.

1.1 유효성검사(`@Valid`) 실패에 따른 400 예외
- 모든 API의 유효성 검사시 GlobalExceptionHanlder을 통해 예외를 핸들링하기로 정했기에 각자 도메인에는 유효성 검사 실패시 발생하는 `MethodArgumentNotValidException` 에 대한 핸들링이 필요없습니다.

1.2. 요청을 찾을 수 없는 404 예외

1.3. 서버 내부 문제가 발생할 경우의 500 예외
- 500 예외의 경우 서버에서 정확한 문제가 무엇인지 파악을 돕기 위해 exception의 스택 트레이스 로그를 출력하도록 구현했습니다.
- 500 예외 발생시 아래와 같은 스택 트레이스 로그를 볼 수 있습니다.

<img width="1349" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/59594946/8a8a450a-66af-4824-b78c-77f1b78cf24b">

<img width="1409" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/59594946/a5743671-1fdd-462b-8eba-79eeac3db142">

### 2. 도메인별 유효 예외 처리 기능 추가

먼저는 Attach 도메인을 기준으로 예외를 핸들링 할수 있도록 아래와 같은 예외 클래스를 추가했습니다.

    2.1 `ImageUploadOutOfRangeException`: 시스템이 정의한 이미지 개수 범위를 벗어날 경우 400 예외 발생
    2.2 `AttachNotFoundException`: 존재하지 않는 Attach 객체를 찾고자 할 경우 404 예외 발생

### 3. 변경사항

- 전역 예외 처리 클래스 GlobalExceptionHandler가 기존 member 패키지에 존재했기에 해당 클래스명을 `MemberControllerAdvice`로 변경했음을 알립니다.
- 예외 정보 전달을 위한 ErrorCode 인터페이스를 확장해 전역 예외 정보와 도메인별 예외 정보를 구분하여 전달하기 위해 ErrorCode, CommonErrorCode로 분리했습니다. 이때, member 패키지의 기존 ErrorCode 또한 MemberErrorCode로 변경했음을 알립니다.

<br>

## ✅ `Attach` 도메인의 비즈니스 로직 개선
1. 예외 처리 로직 추가에 따른 불필요한 try/catch문을 제거했습니다.
2. 비즈니스 메서드 내에서 예외 처리에 따른 분기를 추가했습니다.
3. 일부 메서드의 로직을 Stream 및 Lamda 식으로 개선했습니다.

<br>

## ✅ 테스트 코드
- 예외 처리 로직이 추가됨에 따라 assertThrownBy 구절로 예외 검증을 할 수 있는 테스트 코드 일부를 추가했습니다.

<img width="743" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/59594946/0d81f220-1798-409c-9e33-50ecb07c999f">

<br>

## 🤔 고민거리
- Payload라는 API의 성공,예외에 따른 응답 객체를 만들어 사용하려 했으나 제네릭 타입의 필드를 테스트코드에서 검증하기 어려운 상황이 발생하여 응답 객체 일반화에 대한 부분은 시간이 조금 걸릴 것으로 보입니다. 
    - 현재는 예외일 경우만 Payload의 errorPayload로 Payload의 인스턴스를 만들어 응답합니다.
- 이미지 개수와 같은 시스템의 정책적인 Enum 상수값 등을 주입받아 사용하는 코드를 어떻게 잘 개발할 수 있을지 고민중에 있습니다.
- 테스트 코드 또한 인수테스트나 단위테스트에 대한 지식이 부족하여 계속 공부하며 적용해볼 에정입니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @byeongJoo05 @hb9397 @IToriginal

close #62 
