### PR TITLE
[Feat] 게시글 예외 처리 로직 추가하기

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/board/controller/BoardControllerAdvice.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/controller/BoardControllerAdvice.java
@@ -1,0 +1,38 @@
+package com.kakao.saramaracommunity.board.controller;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.kakao.saramaracommunity.board.exception.BoardNotFoundException;
+import com.kakao.saramaracommunity.common.dto.Payload;
+
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * BoardControllerAdvice: Board(게시글) 관련 예외를 처리할 클래스
+ * 가장 높은 우선순위로 예외 핸들링
+ */
+@Log4j2
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class BoardControllerAdvice {
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(BoardNotFoundException.class)
+    public ResponseEntity<Payload> handleBoardNotFound(BoardNotFoundException exception) {
+
+        log.error("[BoardNotFoundException]");
+
+        return ResponseEntity
+            .status(exception.getStatusWithCode().getHttpStatus())
+            .body(Payload.errorPayload(
+                exception.getStatusWithCode().getHttpStatus().value(),
+                exception.getStatusWithCode().getMessage()
+            ));
+    }
+}

--- a/src/main/java/com/kakao/saramaracommunity/board/dto/request/BoardRequestDto.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/dto/request/BoardRequestDto.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.kakao.saramaracommunity.board.entity.CategoryBoard;
 
+import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -26,13 +27,14 @@ public class BoardRequestDto {
         @NotBlank(message = "내용을 입력해주세요.")
         private String content;
 
-        @NotNull(message = "카테고리를 선택해주세요.")
+        @NotNull(message = "카테고리가 선택되지 않았습니다.")
         private CategoryBoard categoryBoard;
 
         @NotNull(message = "사용자의 고유번호가 존재하지 않습니다.")
         private Long memberId;
 
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        @Future(message = "유효 기간은 현재 시간 이후로 설정해야 합니다.")
         private LocalDateTime deadLine;
     }
 
@@ -41,6 +43,7 @@ public class BoardRequestDto {
     @Getter
     @Builder
     public static class UpdateRequestDto {
+        private Long memberId;
 
         @NotBlank(message = "제목을 입력해주세요.")
         private String title;
@@ -48,10 +51,11 @@ public class BoardRequestDto {
         @NotBlank(message = "내용을 입력해주세요.")
         private String content;
 
-        @NotNull(message = "카테고리를 선택해주세요.")
+        @NotNull(message = "카테고리가 선택되지 않았습니다.")
         private CategoryBoard categoryBoard;
 
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        @Future(message = "유효 기간은 현재 시간 이후로 설정해야 합니다.")
         private LocalDateTime deadLine;
     }
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/entity/Board.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/entity/Board.java
@@ -82,4 +82,11 @@ public class Board extends BaseTimeEntity {
     public void setDeadLine(LocalDateTime deadLine) {
         this.deadLine = deadLine;
     }
+
+    public void updateBoard(String title, String content, CategoryBoard categoryBoard, LocalDateTime deadLine) {
+        this.title = title;
+        this.content = content;
+        this.categoryBoard = categoryBoard;
+        this.deadLine = deadLine;
+    }
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/exception/BoardErrorCode.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/exception/BoardErrorCode.java
@@ -12,17 +12,6 @@ import lombok.RequiredArgsConstructor;
 public enum BoardErrorCode implements ErrorCode {
 
     /**
-     * 500 ERROR
-     * BOARD_CREATE_FAILED: 게시글 작성에 서버 문제가 발생할 경우 500 에러코드를 반환
-     * BOARD_UPDATE_FAILED: 게시글 수정에 서버 문제가 발생할 경우 500 에러코드를 반환
-     * BOARD_DELETE_FAILED: 게시글 삭제에 서버 문제가 발생할 경우 500 에러코드를 반환
-     */
-    BOARD_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "게시글 작성에 실패하였습니다."),
-    BOARD_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "게시글 수정에 실패하였습니다."),
-    BOARD_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "게시글 삭제에 실패하였습니다."),
-
-
-    /**
      * 403 ERROR
      * UNAUTHORIZED_TO_UPDATE_BOARD: 게시글 작성, 수정, 삭제에 연관되어 있는 회원 고유 PK가 DB에 없는 경우 사용자가 없다 판단하여, 403 에러코드를 반환
      */

--- a/src/main/java/com/kakao/saramaracommunity/board/exception/BoardErrorCode.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/exception/BoardErrorCode.java
@@ -1,0 +1,40 @@
+package com.kakao.saramaracommunity.board.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.kakao.saramaracommunity.common.exception.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum BoardErrorCode implements ErrorCode {
+
+    /**
+     * 500 ERROR
+     * BOARD_CREATE_FAILED: 게시글 작성에 서버 문제가 발생할 경우 500 에러코드를 반환
+     * BOARD_UPDATE_FAILED: 게시글 수정에 서버 문제가 발생할 경우 500 에러코드를 반환
+     * BOARD_DELETE_FAILED: 게시글 삭제에 서버 문제가 발생할 경우 500 에러코드를 반환
+     */
+    BOARD_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "게시글 작성에 실패하였습니다."),
+    BOARD_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "게시글 수정에 실패하였습니다."),
+    BOARD_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "게시글 삭제에 실패하였습니다."),
+
+
+    /**
+     * 403 ERROR
+     * UNAUTHORIZED_TO_UPDATE_BOARD: 게시글 작성, 수정, 삭제에 연관되어 있는 회원 고유 PK가 DB에 없는 경우 사용자가 없다 판단하여, 403 에러코드를 반환
+     */
+    UNAUTHORIZED_TO_UPDATE_BOARD(HttpStatus.FORBIDDEN, "권한이 없는 사용자입니다."),
+
+    /**
+     * 404 ERROR
+     * BOARD_NOT_FOUND: 게시글 조회, 수정 및 삭제에서 대상 게시글이 DB에 없는 경우, 404 에러코드를 반환
+     */
+    BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+}

--- a/src/main/java/com/kakao/saramaracommunity/board/exception/BoardInternalServerException.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/exception/BoardInternalServerException.java
@@ -1,0 +1,19 @@
+package com.kakao.saramaracommunity.board.exception;
+
+import lombok.Getter;
+
+
+/**
+ * BoardInternalServerException: Board(게시글)의 작성, 조회, 수정, 삭제에 서버 문제가 발생할 경우 발생시킬 예외 클래스
+ * Unchecked Exception(RuntimeException)을 상속받기에 예외가 발생하면 롤백을 수행.
+ */
+@Getter
+public class BoardInternalServerException extends RuntimeException {
+
+    private final BoardErrorCode statusWithCode;
+
+    public BoardInternalServerException(BoardErrorCode statusWithCode) {
+        super(statusWithCode.getMessage());
+        this.statusWithCode = statusWithCode;
+    }
+}

--- a/src/main/java/com/kakao/saramaracommunity/board/exception/BoardNotFoundException.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/exception/BoardNotFoundException.java
@@ -1,0 +1,18 @@
+package com.kakao.saramaracommunity.board.exception;
+
+import lombok.Getter;
+
+/**
+ * BoardNotFoundException: Board(게시글)를 찾지 못할 경우 발생시킬 예외 클래스
+ * Unchecked Exception(RuntimeException)을 상속받기에 예외가 발생하면 롤백을 수행.
+ */
+@Getter
+public class BoardNotFoundException extends RuntimeException {
+
+    private final BoardErrorCode statusWithCode;
+
+    public BoardNotFoundException(BoardErrorCode statusWithCode) {
+        super(statusWithCode.getMessage());
+        this.statusWithCode = statusWithCode;
+    }
+}

--- a/src/main/java/com/kakao/saramaracommunity/board/exception/BoardUnauthorizedException.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/exception/BoardUnauthorizedException.java
@@ -1,0 +1,18 @@
+package com.kakao.saramaracommunity.board.exception;
+
+import lombok.Getter;
+
+/**
+ * BoardUnauthorizedException: 사용자의 권한이 없을 때 발생시키는 예외 클래스
+ * Unchecked Exception(RuntimeException)을 상속받기에 예외가 발생하면 롤백을 수행.
+ */
+@Getter
+public class BoardUnauthorizedException extends RuntimeException{
+
+    private final BoardErrorCode statusWithCode;
+
+    public BoardUnauthorizedException(BoardErrorCode statusWithCode) {
+        super(statusWithCode.getMessage());
+        this.statusWithCode = statusWithCode;
+    }
+}

--- a/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
@@ -47,11 +47,7 @@ public class BoardServiceImpl implements BoardService {
             .deadLine(deadLine)
             .build();
 
-        Board saveBoard = boardRepository.save(board);
-        if (saveBoard == null) {
-            throw new BoardInternalServerException(BoardErrorCode.BOARD_CREATE_FAILED);
-        }
-        return saveBoard;
+        return boardRepository.save(board);
     }
 
     @Override
@@ -140,10 +136,7 @@ public class BoardServiceImpl implements BoardService {
         board.setDeadLine(requestDto.getDeadLine());
 
         // 수정된 게시글을 저장
-        Board updateBoard = boardRepository.save(board);
-        if (updateBoard == null) {
-            throw new BoardInternalServerException(BoardErrorCode.BOARD_UPDATE_FAILED);
-        }
+        boardRepository.save(board);
         return true;
     }
 
@@ -157,7 +150,7 @@ public class BoardServiceImpl implements BoardService {
 
         boardRepository.deleteById(boardId);
         if (boardRepository.existsById(boardId)) {
-            throw new BoardInternalServerException(BoardErrorCode.BOARD_DELETE_FAILED);
+            throw new BoardInternalServerException(BoardErrorCode.UNAUTHORIZED_TO_UPDATE_BOARD);
         }
         return true;
     }

--- a/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
@@ -130,10 +130,11 @@ public class BoardServiceImpl implements BoardService {
         log.info("요청에 따라 게시글을 수정합니다.(Update the post as requested.)");
 
         // 요청된 데이터로 수정할 내용 업데이트
-        board.setTitle(requestDto.getTitle());
-        board.setContent(requestDto.getContent());
-        board.setCategoryBoard(requestDto.getCategoryBoard());
-        board.setDeadLine(requestDto.getDeadLine());
+        board.updateBoard(
+            requestDto.getTitle(),
+            requestDto.getContent(),
+            requestDto.getCategoryBoard(),
+            requestDto.getDeadLine());
 
         // 수정된 게시글을 저장
         boardRepository.save(board);


### PR DESCRIPTION
## 🤔 Motivation
- 게시글에 관련된 API 요청에 대한 예외처리를 구현하였습니다.

<br>

## 💡 Key Changes
- 전역 예외처리 기능이 추가됨에 따라서 Board 서비스의 예외 처리를 위해 알맞은 HttpCode를 응답하도록 클래스를 생성하였습니다.
- 게시글 투표의 기간을 설정하기 위한 컬럼인 deadLine에 과거시간은 예외로 처리할 수 있도록, @Future 어노테이션을 추가하였습니다.

<br>

## 🧐 Insufficient Content
- 게시물의 유효기간인 deadLine의 유효성 검사 테스트를 하면서 발생한 이슈입니다. 아래와 같이 GlobalExceptionHandler에 적용된 `HttpHeaders`와 `HttpStatusCode`가 적용되어 있지 않다고 에러가 발생하여 정해진 Payload의 형식으로 응답하지 않는 것을 확인했습니다. 
```java
 @ExceptionHandler(MethodArgumentNotValidException.class)
    protected ResponseEntity<Payload> handleMethodArgumentNotValidException (
            MethodArgumentNotValidException exception,
            HttpHeaders headers,
            HttpStatusCode status,
            WebRequest request
    ) { ... }
}
```
<img width="1552" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/117193889/954baf5a-8378-4a8a-b472-40d731c96daf">

- 이를 해결하기 위해 발생한 에러를 확인했는데 요청에 적합한  파라미터가 없다는 것을 나타내는 것 같아서 `HttpHeaders`와 `HttpStatusCode`를 주석처리 후 확인해보니 Payload가 적절하게 적용되는 것을 확인했습니다. 

![image](https://github.com/four-uncles/saramara-community-server/assets/117193889/48b5115e-34fd-433e-9fac-37f6420b5a39)
<img width="1016" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/117193889/495166b7-3a1a-463b-86d2-b68273295284">

- 매개변수를 삭제하지 않았을 때와 삭제했을 때의 응답 결과가 다르게 나타난 이유는 Spring MVC의 내부 동작 차이로 추측하고 있습니다.. 
- 매개변수를 삭제하지 않은 경우에는 Spring MVC가 자동으로 HTTP 응답을 생성할 때, 여러가지 추가 정보를 함께 포함시키기 때문에 불필요한 값이 응답에 포함시켜서 이와 같은 응답을 주는 것 같습니다..
- 정확한 원인을 파악하지 못해서 함께 해결하고자 공유합니다. (단순히 없애기만 하면 해결은 되나, 동작원리에 대해 잘 모르고 있기 때문에 이와 같은 원인을 잘 파악하지 못한다고 생각합니다. 🥲 때문에 이와 같은 이유에 대해 아시는 분이 있다면 함께 고민을 나눠보면 좋을 것 같습니다.)
- ----------
**주간 회의를 통해 추가된 고민 사항 공유**
- 권한에 대한 고민이였습니다. 먼저 회원을 통해서 권한이 인증되지 않은 사용자에 대해서 1차적으로 필터링이 될텐데,,, </br> 문득 `boardId`나 `commentId `그리고 `memberId`가 `long` 타입을 통해서 정수의 값이 PK 값으로 사용되었고, API를 보내게 될 때 다른 PK에 접근이 쉬운게 아닌가 하는 의문? 걱정이 들었었습니다.
- 주간 회의를 통해 UUID로 변경하면 이와 같은 문제가 해결되지 않을까? 하는 의견을 냈었는데, UUID를 사용해도 PK값이 노출되지 않는 보장이 없기 때문에 의미가 없다는 생각을 하게 되었습니다.
- 그래서, 권한에 대한 고민으로 1차적으로 당연하게 Member에서 권한을 필터링하고, 각 서비스 내에서도 권한에 대한 예외처리를 하게 된다면 조금 더 안전한 처리가 되지 않을까 고민하였습니다.
- 현재 제가 작성한 게시글 기능에는 `updateBoard` 메서드에서 DataBase에 등록된 memberId와 일치 하지 않는다면, 권한이 없다는 403 Error를 예외로 처리하도록 개발하였습니다. 이와 같은 방안으로 조금 더 안전한 코드를 작성할 수 있지 않을까 생각해봅니다..

## 👨‍👨‍👧‍👦 To Reviewers
- @langoustinee @byeongJoo05 @hb9397 
- 위의 개발 내용에 대한 코드 리뷰 및 피드백 부탁드립니다.
- 추가적으로 개선할 수 있는 부분이나 주의해야 할 사항이 있다면 알려주시면 감사하겠습니다.