### PR TITLE
[Hotfix] GlobalExceptionHandler의 유효성 검사시 발생할 에외 메서드 문제 해결

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/common/dto/Payload.java
+++ b/src/main/java/com/kakao/saramaracommunity/common/dto/Payload.java
@@ -1,8 +1,8 @@
 package com.kakao.saramaracommunity.common.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.*;
-import org.springframework.http.HttpStatus;
+import lombok.Builder;
+import lombok.Getter;
 
 /**
  * 공통 ResponseDTO로 사용할 Payload 클래스입니다.
@@ -26,7 +26,7 @@ public class Payload<T> {
      * @param message - 오류 메세지
      * @return Payload
      */
-    public static <T>Payload<T> errorPayload(final Integer status, final String message) {
+    public static <T> Payload<T> errorPayload(final Integer status, final String message) {
 
         return Payload.<T>builder()
                 .status(status)
@@ -42,7 +42,7 @@ public class Payload<T> {
      * @param data - 던져줄 데이터
      * @return Payload
      */
-    public static <T>Payload<T> successPayload(final Integer status, final String message, final T data) {
+    public static <T> Payload<T> successPayload(final Integer status, final String message, final T data) {
 
         return Payload.<T>builder()
                 .status(status)

--- a/src/main/java/com/kakao/saramaracommunity/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakao/saramaracommunity/common/exception/GlobalExceptionHandler.java
@@ -5,14 +5,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.core.annotation.Order;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 /**
@@ -33,16 +30,14 @@ public class GlobalExceptionHandler {
      * 유효성 검사를 진행할 @Valid 어노테이션이 붙은 요청 DTO 클래스에서 유효성 검사가 실패할 경우 발생하는 예외를 핸들링하는 메서드입니다.
      * 메시지의 경우 유효성 검사 결과 객체에서 필드 오류 정보를 찾은 후, 해당 예외의 기본 메시지를 추출하여 문자열로 반환합니다.
      *
+     * ResponseEntity를 사용한 이유는 응답 상태 코드, 헤더 등을 더 세밀하게 제어할 수 있기 때문입니다.
+     * 또한, HTTP 응답을 더 세부적으로 커스터마이징할 수 있기 때문에 유연성이 높습니다.
+     *
      * @param exception 유효성 검증 실패 시 던지는 예외
      * @return 예외 메세지와 응답 코드를 리턴
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<Payload> handleMethodArgumentNotValidException (
-            MethodArgumentNotValidException exception,
-            HttpHeaders headers,
-            HttpStatusCode status,
-            WebRequest request
-    ) {
+    protected ResponseEntity<Payload> handleMethodArgumentNotValidException (MethodArgumentNotValidException exception) {
 
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
## 🤔 Motivation
- 전역 예외 처리 클래스의 유효성 검사 예외 메서드에서 발견한 문제 해결

<br>

## 💡 Key Changes

### `GlobalExceptionHandler`의 `handleMethodArgumentNotValidException` 메서드의 문제 파악

본래 전역 예외 처리 클래스에서 유효성 검사 예외의 경우 아래와 같이 `ResponseEntityExceptionHandler`를 상속받아 `handleMethodArgumentNotValid` 메서드를 재정의하여 작성했었습니다.

```java
@Override
protected ResponseEntity<Object> handleMethodArgumentNotValid(
    MethodArgumentNotValidException ex, 
    HttpHeaders headers, 
    HttpStatusCode status, 
    WebRequest request
) {
    return super.handleMethodArgumentNotValid(ex, headers, status, request);
}
```

이후 우리가 정의한 Payload라는 응답 객체로 응답 형식을 커스터마이징하여 보내기 위해 유효성 검사 메서드를 재정의하지 않고 직접 구현하는 방식으로 수정했습니다.

```java
@ExceptionHandler(MethodArgumentNotValidException.class)
protected ResponseEntity<Payload> handleMethodArgumentNotValidException (
    MethodArgumentNotValidException exception,
    HttpHeaders headers,
    HttpStatusCode status,
    WebRequest request
) { ... }
```

바로 여기서 문제가 발생했는데요. 메서드의 시그니처를 그대로 방치했다보니, Spring Validation을 통한 **유효성 검사 예외 테스트시 기대한 응답 형식으로 응답되지 않는 문제**가 있었습니다. 메서드 시그니처와 관련하여  찾아보니 다음과 같은 결론을 낼 수 있었습니다.

### 문제 분석

`handleMethodArgumentNotValid` 메서드를 직접 구현할 때 `HttpHeaders headers`, `HttpStatusCode status`, 그리고 `WebRequest request`와 같은 파라미터를 사용하지 못하는 이유는 해당 파라미터들은 `ResponseEntityExceptionHandler` 클래스의 `handleMethodArgumentNotValid` 메서드에서만 사용되는 내부 파라미터들이기 때문이라고 합니다. 이들은 스프링의 내부 인터페이스와 구조에 관련되어서 프레임워크 자체적으로 예외 처리와 응답 생성을 다루기 위해 사용되는 것이기에 직접 유효성 검사에 대한 예외를 처리할 `handleMethodArgumentNotValid`메서드를 구현할 때는 사용할 수 없는 파라미터인 것입니다.

그래서 결국, **메서드의 시그니처를 그대로 방치하여 문제가 발생한 것**으로 문제가 무엇인지 특정지을 수 있었습니다. 

### 문제 해결

```java
@ExceptionHandler(MethodArgumentNotValidException.class)
    protected ResponseEntity<Payload> handleMethodArgumentNotValidException (MethodArgumentNotValidException exception) { ... }
```
메서드 시그니처는 제거하여 테스트해보니, 정상적으로 기대한 예외 응답을 받을 수 있었습니다.

<img width="965" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/59594946/53fc78a1-a388-4c1a-868d-b4ef3b110587">

향후 개발시 이러한 문제가 다시 생기지 않도록 유의하겠습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @byeongJoo05 @hb9397 @IToriginal 

close #73 
