### PR TITLE
[Feat] Presentation Layer 테스트 작성 및 테스트 환경 통합

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/attach/controller/AttachController.java
+++ b/src/main/java/com/kakao/saramaracommunity/attach/controller/AttachController.java
@@ -82,7 +82,7 @@ public class AttachController {
      *
      * @return AttachResponse.DeleteResponse
      */
-    @DeleteMapping("/board")
+    @DeleteMapping("/board/{attachId}")
     public ResponseEntity<AttachResponse.DeleteResponse> deleteImage(@Valid @PathVariable Long attachId) {
         AttachResponse.DeleteResponse response = attachService.deleteImage(attachId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(response);

--- a/src/main/java/com/kakao/saramaracommunity/bucket/controller/BucketController.java
+++ b/src/main/java/com/kakao/saramaracommunity/bucket/controller/BucketController.java
@@ -17,8 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Taejun
  * @version 0.0.1
  */
-@RequiredArgsConstructor
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/bucket")
 public class BucketController {
 
@@ -31,7 +31,7 @@ public class BucketController {
      * @param request type, id, imgList
      * @return BucketResponse.BucketUploadResponse
      */
-    @PostMapping("/upload/bucket")
+    @PostMapping("/upload")
     public ResponseEntity<BucketResponse.BucketUploadResponse> bucketUploadImages(@RequestBody @Valid BucketRequest.BucketUploadRequest request) {
         BucketResponse.BucketUploadResponse response = bucketService.bucketUploadImages(request.toServiceRequest());
         return ResponseEntity.ok().body(response);

--- a/src/main/java/com/kakao/saramaracommunity/bucket/service/BucketServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/bucket/service/BucketServiceImpl.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 
 import static com.kakao.saramaracommunity.bucket.exception.BucketErrorCode.BUCKET_IMAGE_RANGE_OUT;
 
+
 /**
  * BucketServiceImpl: AWS S3 버킷에 클라이언트의 요청 이미지를 업로드하기 위한 비즈니스 로직을 수행할 서비스 인터페이스의 구현체 클래스
  *
@@ -23,8 +24,8 @@ import static com.kakao.saramaracommunity.bucket.exception.BucketErrorCode.BUCKE
  * @version 0.0.1
  */
 @Log4j2
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class BucketServiceImpl implements BucketService {
 
     private final AwsS3Uploader awsS3Uploader;

--- a/src/main/java/com/kakao/saramaracommunity/config/AwsS3Config.java
+++ b/src/main/java/com/kakao/saramaracommunity/config/AwsS3Config.java
@@ -1,8 +1,9 @@
 package com.kakao.saramaracommunity.config;
 
+import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -16,8 +17,8 @@ import org.springframework.context.annotation.Profile;
  * @author Taejun
  * @version 0.0.1
  */
-@Profile("!test")
 @Configuration
+@Profile("!test")
 public class AwsS3Config {
 
     @Value("${cloud.aws.credentials.accessKey}")
@@ -30,10 +31,10 @@ public class AwsS3Config {
     private String region;
 
     @Bean
-    public AmazonS3Client amazonS3Client() {
-        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
-        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
-                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
                 .withRegion(region)
                 .build();
     }

--- a/src/main/java/com/kakao/saramaracommunity/config/SecurityConfig.java
+++ b/src/main/java/com/kakao/saramaracommunity/config/SecurityConfig.java
@@ -76,7 +76,7 @@ public class SecurityConfig {
         httpSecurity
                 .authorizeHttpRequests()
                 .requestMatchers( "/favicon.ico","/error", "/api/authenticate","/api/v1/member/**", "/api/login").permitAll()
-                .requestMatchers("/auth/**", "/oauth2/**", "/api/v1/board/**", "/api/v1/comment/**", "/api/v1/attach/**").permitAll()
+                .requestMatchers("/auth/**", "/oauth2/**", "/api/v1/board/**", "/api/v1/comment/**", "/api/v1/attach/**", "/api/v1/bucket/**").permitAll()
                 .anyRequest().authenticated();
 
         httpSecurity.addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/kakao/saramaracommunity/member/controller/MemberControllerAdvice.java
+++ b/src/main/java/com/kakao/saramaracommunity/member/controller/MemberControllerAdvice.java
@@ -24,7 +24,7 @@ Exception에 대한 결과를 ErrorCode 클래스를 이용해서 MemberResDto�
 @Log4j2
 @RequiredArgsConstructor
 @RestControllerAdvice
-@Order(Ordered.HIGHEST_PRECEDENCE)
+@Order
 public class MemberControllerAdvice {
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/kakao/saramaracommunity/util/AwsS3Uploader.java
+++ b/src/main/java/com/kakao/saramaracommunity/util/AwsS3Uploader.java
@@ -1,6 +1,6 @@
 package com.kakao.saramaracommunity.util;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -20,11 +20,11 @@ import java.io.InputStream;
  * @version 0.0.1
  */
 @Log4j2
-@RequiredArgsConstructor
 @Component
+@RequiredArgsConstructor
 public class AwsS3Uploader {
 
-    private final AmazonS3Client amazonS3Client;
+    private final AmazonS3 amazonS3Client;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;

--- a/src/test/java/com/kakao/saramaracommunity/attach/controller/AttachControllerTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/attach/controller/AttachControllerTest.java
@@ -1,0 +1,348 @@
+package com.kakao.saramaracommunity.attach.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakao.saramaracommunity.attach.controller.dto.request.AttachRequest;
+import com.kakao.saramaracommunity.attach.exception.ImageUploadOutOfRangeException;
+import com.kakao.saramaracommunity.attach.service.AttachService;
+import com.kakao.saramaracommunity.attach.service.dto.response.AttachResponse;
+import com.kakao.saramaracommunity.support.ControllerTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.kakao.saramaracommunity.attach.entity.AttachType.BOARD;
+import static com.kakao.saramaracommunity.attach.exception.AttachErrorCode.ATTACH_IMAGE_RANGE_OUT;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * AttachControllerTest: Presentation Layer인 AttachController를 테스트할 클래스
+ * @WebMvcTest를 통해 웹 계층을 슬라이스 테스트로 진행한다.
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+class AttachControllerTest extends ControllerTestSupport {
+
+    @DisplayName("새로운 이미지 목록을 등록한다.")
+    @Test
+    void uploadImages() throws Exception {
+        // given
+        Map<Long, String> images = createImageMap(3);
+
+        AttachRequest.UploadRequest request = AttachRequest.UploadRequest.builder()
+                .attachType(BOARD)
+                .ids(1L)
+                .imgList(images)
+                .build();
+
+        given(attachService.uploadImages(any()))
+                .willReturn(AttachResponse.UploadResponse.builder()
+                        .code(200)
+                        .msg("정상적으로 DB에 이미지 업로드를 완료했습니다.")
+                        .data(true)
+                        .build()
+        );
+
+        // when & then
+        mockMvc.perform(
+                        post("/api/v1/attach/upload")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.msg").value("정상적으로 DB에 이미지 업로드를 완료했습니다."))
+                .andExpect(jsonPath("$.data").isBoolean());
+    }
+
+    @DisplayName("새로운 이미지 목록을 등록할 때, 첨부파일의 유형은 필수로 입력되어야 한다.")
+    @Test
+    void uploadImagesWithoutAttachType() throws Exception {
+        // given
+        Map<Long, String> images = createImageMap(0);
+        AttachRequest.UploadRequest request = AttachRequest.UploadRequest.builder()
+                .ids(1L)
+                .imgList(images)
+                .build();
+
+        // when & then
+        mockMvc.perform(
+                        post("/api/v1/attach/upload")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("400"))
+                .andExpect(jsonPath("$.message", containsString("어떤 유형의 글에서 이미지가 등록되었는지 알 수 없습니다.")));
+    }
+
+    @DisplayName("새로운 이미지 목록을 등록할 때, 게시글 번호는 필수로 입력되어야 한다.")
+    @Test
+    void uploadImagesWithoutBoardId() throws Exception {
+        // given
+        Map<Long, String> images = createImageMap(0);
+        AttachRequest.UploadRequest request = AttachRequest.UploadRequest.builder()
+                .attachType(BOARD)
+                .imgList(images)
+                .build();
+
+        // when & then
+        mockMvc.perform(
+                        post("/api/v1/attach/upload")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("400"))
+                .andExpect(jsonPath("$.message", containsString("게시글이나 댓글의 번호값을 알 수 없습니다.")));
+    }
+
+    @DisplayName("새로운 이미지 목록을 등록할 때, 이미지 목록은 필수로 입력되어야 한다.")
+    @Test
+    void uploadImagesWithoutImgList() throws Exception {
+        // given
+        AttachRequest.UploadRequest request = AttachRequest.UploadRequest.builder()
+                .attachType(BOARD)
+                .ids(1L)
+                .build();
+
+        // when & then
+        mockMvc.perform(
+                        post("/api/v1/attach/upload")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("400"))
+                .andExpect(jsonPath("$.message", containsString("이미지 목록이 비어있습니다.")));
+    }
+
+    @DisplayName("새로운 이미지 목록을 등록할 때, 이미지는 1장 이상이어야 한다.")
+    @Test
+    void uploadImagesImageListIsEmpty() throws Exception {
+        // given
+        Map<Long, String> imgList = createImageMap(0);
+
+        AttachRequest.UploadRequest request = AttachRequest.UploadRequest.builder()
+                .attachType(BOARD)
+                .ids(1L)
+                .imgList(imgList)
+                .build();
+
+        given(attachService.uploadImages(any()))
+                .willThrow(new ImageUploadOutOfRangeException(ATTACH_IMAGE_RANGE_OUT));
+
+        // when & then
+        mockMvc.perform(
+                        post("/api/v1/attach/upload")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(ATTACH_IMAGE_RANGE_OUT.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message").value(ATTACH_IMAGE_RANGE_OUT.getMessage()));
+    }
+
+    @WithMockUser(roles = "USER")
+    @DisplayName("새로운 이미지 목록을 등록할 때, 이미지가 6장 이상일 경우 예외가 발생한다.")
+    @Test
+    void uploadImagesImageListIsRangeOut() throws Exception {
+        // given
+        Map<Long, String> imgList = createImageMap(6);
+
+        AttachRequest.UploadRequest request = AttachRequest.UploadRequest.builder()
+                .attachType(BOARD)
+                .ids(1L)
+                .imgList(imgList)
+                .build();
+
+        given(attachService.uploadImages(any()))
+                .willThrow(new ImageUploadOutOfRangeException(ATTACH_IMAGE_RANGE_OUT));
+
+        // when & then
+        mockMvc.perform(
+                        post("/api/v1/attach/upload")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(ATTACH_IMAGE_RANGE_OUT.getHttpStatus().value()))
+                .andExpect(jsonPath("$.message").value(ATTACH_IMAGE_RANGE_OUT.getMessage()));
+    }
+
+    @DisplayName("특정 게시글의 이미지 목록을 조회한다.")
+    @Test
+    void getBoardImages() throws Exception {
+        // given
+        AttachRequest.GetBoardImageRequest request = AttachRequest.GetBoardImageRequest.builder()
+                .attachType(BOARD)
+                .ids(1L)
+                .build();
+
+        Map<Long, Map<Long, String>> result = Map.of();
+        given(attachService.getBoardImages(any()))
+                .willReturn(AttachResponse.GetImageResponse.builder()
+                        .code(200)
+                        .msg("정상적으로 해당 게시글의 등록된 이미지 목록을 조회하였습니다.")
+                        .data(result)
+                        .build());
+
+        // when & then
+        mockMvc.perform(
+                        get("/api/v1/attach/board")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.msg").value("정상적으로 해당 게시글의 등록된 이미지 목록을 조회하였습니다."))
+                .andExpect(jsonPath("$.data").isMap());
+    }
+
+    @DisplayName("특정 게시글의 이미지 목록을 조회할 때, 게시글번호는 필수로 입력되어야 한다.")
+    @Test
+    void getBoardImagesWithoutBoardId() throws Exception {
+        // given
+        AttachRequest.GetBoardImageRequest request = AttachRequest.GetBoardImageRequest.builder()
+                .attachType(BOARD)
+                .build();
+
+        // when & then
+        mockMvc.perform(
+                        get("/api/v1/attach/board")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("400"))
+                .andExpect(jsonPath("$.message", containsString("게시글이나 댓글의 번호값을 알 수 없습니다.")));
+    }
+
+    @DisplayName("모든 게시글의 이미지 목록들을 조회한다.")
+    @Test
+    void getAllBoardImages() throws Exception {
+        // given
+        Map<Long, Map<Long, String>> result = Map.of();
+        given(attachService.getAllBoardImages())
+                .willReturn(AttachResponse.GetAllImageResponse.builder()
+                        .code(200)
+                        .msg("정상적으로 모든 게시글의 등록된 이미지 목록을 조회하였습니다.")
+                        .data(result)
+                        .build());
+
+        // when & then
+        mockMvc.perform(
+                        get("/api/v1/attach/boards")
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.msg").value("정상적으로 모든 게시글의 등록된 이미지 목록을 조회하였습니다."))
+                .andExpect(jsonPath("$.data").isMap());
+    }
+
+    @DisplayName("게시글의 이미지 목록에서 하나의 이미지를 변경한다.")
+    @Test
+    void updateImage() throws Exception {
+        // given
+        AttachRequest.UpdateRequest request = AttachRequest.UpdateRequest.builder()
+                .attachType(BOARD)
+                .attachId(1L)
+                .ids(1L)
+                .imgPath("https://saramara-storage.s3.ap-northeast-2.amazonaws.com/test.png")
+                .build();
+
+        given(attachService.updateImage(any()))
+                .willReturn(AttachResponse.UpdateResponse.builder()
+                        .code(200)
+                        .msg("정상적으로 게시글의 이미지를 수정했습니다.")
+                        .data(true)
+                        .build());
+
+        // when & then
+        mockMvc.perform(
+                        put("/api/v1/attach/board")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.msg").value("정상적으로 게시글의 이미지를 수정했습니다."))
+                .andExpect(jsonPath("$.data").isBoolean());
+    }
+
+    @DisplayName("게시글의 이미지 목록에서 하나의 이미지를 삭제한다.")
+    @Test
+    void deleteImage() throws Exception {
+        // given
+        given(attachService.deleteImage(any()))
+                .willReturn(AttachResponse.DeleteResponse.builder()
+                        .code(204)
+                        .msg("정상적으로 이미지를 삭제했습니다.")
+                        .data(true)
+                        .build());
+
+        // when & then
+        mockMvc.perform(
+                        delete("/api/v1/attach/board/1")
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isNoContent())
+                .andExpect(jsonPath("$.code").value("204"))
+                .andExpect(jsonPath("$.msg").value("정상적으로 이미지를 삭제했습니다."))
+                .andExpect(jsonPath("$.data").isBoolean());
+    }
+
+    /**
+     * 요청에 필요한 이미지 목록을 생성하는 메서드
+     * @param size
+     */
+    private Map<Long, String> createImageMap(int size) {
+        Map<Long, String> images = new HashMap<>();
+        for(int i=1; i<=size; i++) {
+            Long seq = (long) i;
+            images.put(seq, "test" + i + ".jpg");
+        }
+        return images;
+    }
+
+}

--- a/src/test/java/com/kakao/saramaracommunity/attach/repository/AttachRepositoryTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/attach/repository/AttachRepositoryTest.java
@@ -1,0 +1,75 @@
+package com.kakao.saramaracommunity.attach.repository;
+
+import com.kakao.saramaracommunity.attach.entity.Attach;
+import com.kakao.saramaracommunity.attach.entity.AttachType;
+import com.kakao.saramaracommunity.attach.repository.AttachRepository;
+import com.kakao.saramaracommunity.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.kakao.saramaracommunity.attach.entity.AttachType.BOARD;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.*;
+
+/**
+ * AttachRepositoryTest: Persistence Layer인 AttachRepository를 테스트할 클래스
+ * @DataJpaTest를 통해 JPA Repository 검증을 위한 슬라이스 테스트로 진행한다.
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+@Transactional
+class AttachRepositoryTest extends IntegrationTestSupport {
+    @Autowired
+    private AttachRepository attachRepository;
+
+    @DisplayName("원하는 게시글의 이미지 목록을 조회한다.")
+    @Test
+    void findAllByIds() {
+        // given
+        Attach attach1 = createAttach(BOARD, 1L, 1L, "test1.jpg");
+        Attach attach2 = createAttach(BOARD, 1L, 2L, "test2.jpg");
+        Attach attach3 = createAttach(BOARD, 1L, 3L, "test3.jpg");
+        attachRepository.saveAll(List.of(attach1, attach2, attach3));
+
+        // when
+        List<Attach> attaches = attachRepository.findAllByIds(1L);
+
+        // then
+        assertThat(attaches).hasSize(3)
+                .extracting("type", "ids", "seq", "imgPath")
+                .containsExactlyInAnyOrder(
+                        tuple(BOARD, 1L, 1L, "test1.jpg"),
+                        tuple(BOARD, 1L, 2L, "test2.jpg"),
+                        tuple(BOARD, 1L, 3L, "test3.jpg")
+                );
+    }
+
+    @DisplayName("게시글의 이미지 목록을 가져올 때, 등록된 이미지가 하나도 없다면 빈 목록을 반환한다.")
+    @Test
+    void findAllByIdsWhenAttachesIsEmpty() {
+        // when
+        List<Attach> attaches = attachRepository.findAllByIds(1L);
+
+        // then
+        assertThat(attaches).isEmpty();
+    }
+
+    private Attach createAttach(AttachType type, Long ids, Long seq, String path) {
+        return Attach.builder()
+                .type(type)
+                .ids(ids)
+                .seq(seq)
+                .imgPath(path)
+                .build();
+    }
+
+}

--- a/src/test/java/com/kakao/saramaracommunity/attach/service/AttachServiceImplTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/attach/service/AttachServiceImplTest.java
@@ -1,21 +1,17 @@
 package com.kakao.saramaracommunity.attach.service;
 
-import com.kakao.saramaracommunity.attach.service.dto.response.AttachResponse;
 import com.kakao.saramaracommunity.attach.entity.Attach;
 import com.kakao.saramaracommunity.attach.exception.ImageUploadOutOfRangeException;
 import com.kakao.saramaracommunity.attach.repository.AttachRepository;
 import com.kakao.saramaracommunity.attach.service.dto.request.AttachServiceRequest;
+import com.kakao.saramaracommunity.attach.service.dto.response.AttachResponse;
+import com.kakao.saramaracommunity.support.IntegrationTestSupport;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.context.ApplicationContext;
 
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,15 +22,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 /**
- * AttachServiceImplTest: AttachService의 구현체를 테스트할 클래스
- * Integration Test
- * Attach 테이블과 상호작용하는 기능을 테스트한다.
+ * AttachServiceImplTest: Business Layer인 AttachService의 구현체를 테스트할 클래스
+ * @SpringBootTest를 통한 통합 테스트로 진행한다.
  *
  * @author Taejun
  * @version 0.0.1
  */
-@SpringBootTest
-class AttachServiceImplTest {
+class AttachServiceImplTest extends IntegrationTestSupport {
 
     @Autowired
     AttachRepository attachRepository;
@@ -42,13 +36,18 @@ class AttachServiceImplTest {
     @Autowired
     private AttachService attachService;
 
-    @BeforeEach
-    void setUp() {
-    }
-
     @AfterEach
     void tearDown() {
         attachRepository.deleteAllInBatch();
+    }
+
+    @Autowired
+    ApplicationContext ac;
+
+    @DisplayName("ApplicationContext!!!")
+    @Test
+    void test() {
+        System.out.println(ac);
     }
 
     @DisplayName("1번 게시글에 대한 1장의 이미지 URL(S3 이미지 객체 URL)을 DB에 저장한다.")
@@ -80,10 +79,10 @@ class AttachServiceImplTest {
     void MultipleImageUpload() {
         // given
         Map<Long, String> imgList = new HashMap<>();
-        imgList.put(1L, "https://saramara-storage.s3.ap-northeast-2.amazonaws.com//test_1.png");
-        imgList.put(2L, "https://saramara-storage.s3.ap-northeast-2.amazonaws.com//test_2.png");
-        imgList.put(3L, "https://saramara-storage.s3.ap-northeast-2.amazonaws.com//test_3.png");
-        imgList.put(4L, "https://saramara-storage.s3.ap-northeast-2.amazonaws.com//test_4.png");
+        imgList.put(1L, "https://saramara-storage.s3.ap-northeast-2.amazonaws.com/test_1.png");
+        imgList.put(2L, "https://saramara-storage.s3.ap-northeast-2.amazonaws.com/test_2.png");
+        imgList.put(3L, "https://saramara-storage.s3.ap-northeast-2.amazonaws.com/test_3.png");
+        imgList.put(4L, "https://saramara-storage.s3.ap-northeast-2.amazonaws.com/test_4.png");
         imgList.put(5L, "https://saramara-storage.s3.ap-northeast-2.amazonaws.com//test_5.png");
 
         AttachServiceRequest.UploadRequest request = AttachServiceRequest.UploadRequest.builder()

--- a/src/test/java/com/kakao/saramaracommunity/bucket/controller/BucketControllerTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/bucket/controller/BucketControllerTest.java
@@ -1,0 +1,96 @@
+package com.kakao.saramaracommunity.bucket.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakao.saramaracommunity.bucket.controller.dto.request.BucketRequest;
+import com.kakao.saramaracommunity.bucket.exception.BucketUploadOutOfRangeException;
+import com.kakao.saramaracommunity.bucket.service.BucketService;
+import com.kakao.saramaracommunity.bucket.service.dto.response.BucketResponse;
+import com.kakao.saramaracommunity.support.ControllerTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * BucketControllerTest: Presentaion Layer인 BucketController를 테스트할 클래스
+ * @WebMvcTest를 통해 웹 계층을 슬라이스 테스트로 진행한다.
+ *
+ * List<MultipartFile> 타입 필드의 경우 objectMapper를 통한 직렬화가 불가하기에 Mock을 이용해 Stubbing하여 테스트를 진행했다.
+ *
+ * @author Taejun
+ * @version 0.0.1
+ */
+class BucketControllerTest extends ControllerTestSupport {
+
+    @DisplayName("AWS S3 버킷에 새로운 이미지 목록을 등록한다.")
+    @Test
+    void bucketUploadImages() throws Exception {
+        // given
+        BucketRequest.BucketUploadRequest request = BucketRequest.BucketUploadRequest.builder()
+        .imgList(new ArrayList<>())
+        .build();
+
+        given(bucketService.bucketUploadImages(any()))
+                .willReturn(BucketResponse.BucketUploadResponse.of(
+                        200,
+                        "정상적으로 AWS S3 버킷에 이미지 등록을 완료했습니다.",
+                        List.of(
+                                "https://saramara-storage.s3.ap-northeast-2.amazonaws.com/test.png",
+                                "https://saramara-storage.s3.ap-northeast-2.amazonaws.com/test.png",
+                                "https://saramara-storage.s3.ap-northeast-2.amazonaws.com/test.png"
+                        )
+                ));
+
+        // when & then
+        mockMvc.perform(
+                        post("/api/v1/bucket/upload")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.msg").value("정상적으로 AWS S3 버킷에 이미지 등록을 완료했습니다."))
+                .andExpect(jsonPath("$.data").isArray());
+
+    }
+
+    @DisplayName("AWS S3 버킷에 새로운 이미지 목록을 등록할 때, 이미지 파일 목록은 필수로 입력되어야 한다.")
+    @Test
+    void bucketUploadImagesWithoutImgList() throws Exception {
+        // given
+        BucketRequest.BucketUploadRequest request = BucketRequest.BucketUploadRequest.builder()
+                .build();
+
+        // when & then
+        mockMvc.perform(
+                        post("/api/v1/bucket/upload")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(APPLICATION_JSON)
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("400"))
+                .andExpect(jsonPath("$.message", containsString("이미지 목록이 비어있습니다.")));
+
+    }
+
+}

--- a/src/test/java/com/kakao/saramaracommunity/bucket/service/support/StubData.java
+++ b/src/test/java/com/kakao/saramaracommunity/bucket/service/support/StubData.java
@@ -1,0 +1,15 @@
+package com.kakao.saramaracommunity.bucket.service.support;
+
+import lombok.Getter;
+
+@Getter
+public class StubData {
+
+    @Getter
+    public static class CustomMultipartFile {
+
+        @Getter
+        static final String IMAGE_URL = "https://saramara-storage.s3.ap-northeast-2.amazonaws.com/test.png";
+
+    }
+}

--- a/src/test/java/com/kakao/saramaracommunity/config/AwsS3MockConfig.java
+++ b/src/test/java/com/kakao/saramaracommunity/config/AwsS3MockConfig.java
@@ -8,36 +8,36 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import io.findify.s3mock.S3Mock;
-import org.springframework.boot.test.context.TestConfiguration;
+import org.mockito.Mockito;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
-/**
- * AwsS3MockConfig: AWS S3 버킷 테스트를 위한 설정 클래스
- * 테스트 환경에서만 동작하도록 @Profile 어노테이션을 구성했습니다.
- *
- * @author Taejun
- * @version 0.0.1
- */
 @Profile("test")
-@TestConfiguration
-public class AwsS3MockConfig {
+@Configuration
+public class AwsS3MockConfig extends AwsS3Config {
+
+    @Bean
+    @Primary
+    @Override
+    public AmazonS3 amazonS3() {
+        return Mockito.mock(AmazonS3.class);
+    }
+
     @Bean
     public S3Mock s3Mock() {
         return new S3Mock.Builder().withPort(8001).withInMemoryBackend().build();
     }
-    @Primary
-    @Bean(name = "amazonS3", destroyMethod = "shutdown")
-    public AmazonS3Client amazonS3(){
-        AwsClientBuilder.EndpointConfiguration endpoint = new AwsClientBuilder.EndpointConfiguration("http://localhost:8001", Regions.AP_NORTHEAST_2.name());
-        AmazonS3 client = AmazonS3ClientBuilder
-                .standard()
+
+    @Bean(name = "amazonS3Client", destroyMethod = "shutdown")
+    public AmazonS3Client amazonS3Client(){
+        AwsClientBuilder.EndpointConfiguration endpoint = new AwsClientBuilder.EndpointConfiguration("http://127.0.0.1:8001", Regions.AP_NORTHEAST_2.name());
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
                 .withPathStyleAccessEnabled(true)
                 .withEndpointConfiguration(endpoint)
                 .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
                 .build();
-        return (AmazonS3Client) client;
     }
 
 }

--- a/src/test/java/com/kakao/saramaracommunity/support/ControllerTestSupport.java
+++ b/src/test/java/com/kakao/saramaracommunity/support/ControllerTestSupport.java
@@ -1,0 +1,34 @@
+package com.kakao.saramaracommunity.support;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakao.saramaracommunity.attach.controller.AttachController;
+import com.kakao.saramaracommunity.attach.service.AttachService;
+import com.kakao.saramaracommunity.bucket.controller.BucketController;
+import com.kakao.saramaracommunity.bucket.service.BucketService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WithMockUser(roles = "USER")
+@WebMvcTest(controllers = {
+        AttachController.class,
+        BucketController.class
+})
+public class ControllerTestSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockBean
+    protected AttachService attachService;
+
+    @MockBean
+    protected BucketService bucketService;
+
+}

--- a/src/test/java/com/kakao/saramaracommunity/support/IntegrationTestSupport.java
+++ b/src/test/java/com/kakao/saramaracommunity/support/IntegrationTestSupport.java
@@ -1,0 +1,12 @@
+package com.kakao.saramaracommunity.support;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class IntegrationTestSupport {
+
+}


### PR DESCRIPTION
## 🤔 Motivation
- Attach 도메인의 Presentation Layer(Controller) 테스트 코드 작성
- 스프링 컨텍스트 실행 비용을 줄이기 위한 테스트 환경 통합

<br>

## 💡 Key Changes

### Layer별 테스트 구조
- Presentation Layer(Controller): `@WebMvcTest`를 이용해 웹 계층 테스트에 필요한 빈만 주입받아 슬라이스 테스트
    - Service와 Repository를 Mocking한 테스트, API 요청 응답을 위한 Service를 Mocking한 후, API 명세에 따른 기댓값을 Stubbing하여 검증하는 방식으로 구현했습니다.
- Business Layer(Service): `@SpringBootTest`를 이용해 비즈니스 로직을 위한 모든 빈을 실제로 주입받는 통합 테스트
    - 비즈니스 로직 수행을 위해 필요한 Repository 빈을 실제로 주입받는 통합 테스트로 작성했습니다.
- Persistence Layer(Repository): `@DataJpaTest`를 이용해 JPA 설정에 필요한 빈만 주입받아 슬라이스 테스트
    - JPA 관련 로직만을 테스트하도록 구현했습니다. 컨트롤러 테스트에서 동일한 검증을 수행하기에 추후 작성 유무를 고려할 필요가 있습니다.

위와 같은 구조로 계층별 테스트 코드를 작성하였습니다.

### 테스트 환경 통합
- Presentation Layer: `@WeMvcTest`를 통한 웹 계층만을 테스트하는 환경(추후, Mock 확장에 따른 상위 클래스 구분 필요)에서 Controller를 테스트합니다. 이때, 여러 컨트롤러 슬라이스 테스트 환경을 위한 상위 클래스 `ControllerTestSupport`를 두어 컨트롤러 테스트가 이를 상속받도록 구현했습니다.
- Business Layer & Persistence Layer: `@SpringBootTest`를 통한 통합 테스트 환경에서 Service와 Repository 계층을 함께 테스트합니다. 이때, 서비스와 레포지토리의 통합 테스트 환경을 위한 상위 클래스 `IntegrationTestSupport`를 두어 서비스 테스트와 레포지토리 테스트가 이를 상속받도록 구현했습니다.

> Repository 테스트에 `@DataJpaTest`에서 `@SpringBootTest`로 Service 계층과 동일한 테스트 환경을 구축한 이유는 **`@DataJpaTest`를 사용하는 특별한 이유가 아닌 경우, 통합 테스트에 사용되는 컨텍스트를 재사용하는 이점이 더 크다고 생각**했기 때문입니다.

테스트 환경 통합과 관련하여 블로그 포스팅을 하였으니 자세한 내용은 해당 [포스팅](https://velog.io/@langoustine/context-caching-for-test)을 참조 부탁드립니다.

*자세한 사항은 코드 리뷰를 위한 코멘트를 달아주시면 답변으로 설명드리겠습니다.

<br>

## 🚩향후 개발 계획
- 비즈니스 로직 리팩토링(private 메서드 추출 등)
- Service의 HttpStatus 의존 제거
- 도메인 별 단위 테스트 작성
- Attach 테이블 관계 점검 및 개편

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @byeongJoo05 @hb9397 @IToriginal 

close #86 
close #81 
close #67 
