### PR TITLE
[Feat/Fix] 댓글(Comment) 테스트를 위한 Test Fixture 설정

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/board/entity/AttachBoard.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/entity/AttachBoard.java
@@ -1,6 +1,5 @@
 package com.kakao.saramaracommunity.board.entity;
 
-import com.kakao.saramaracommunity.board.exception.BoardAttachOutOfRangeException;
 import com.kakao.saramaracommunity.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -11,8 +10,6 @@ import lombok.NoArgsConstructor;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
-import static com.kakao.saramaracommunity.board.exception.BoardErrorCode.ATTACH_BOARD_RANGE_OUT;
 
 @Getter
 @Entity

--- a/src/main/java/com/kakao/saramaracommunity/board/entity/AttachBoard.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/entity/AttachBoard.java
@@ -42,7 +42,7 @@ public class AttachBoard extends BaseTimeEntity {
         this.imagePath = imagePath;
     }
 
-    private void update(int imageOrder, String imagePath) {
+    public void update(int imageOrder, String imagePath) {
         this.imageOrder = imageOrder;
         this.imagePath = imagePath;
     }
@@ -55,9 +55,9 @@ public class AttachBoard extends BaseTimeEntity {
 
     public static List<AttachBoard> updateAttachBoards(Board board, List<String> attachPaths) {
         List<AttachBoard> attachBoards = board.getAttachBoards();
-        if (attachBoards.size() != attachPaths.size()) {
-            throw new BoardAttachOutOfRangeException(ATTACH_BOARD_RANGE_OUT);
-        }
+//        if (attachBoards.size() != attachPaths.size()) {
+//            throw new BoardAttachOutOfRangeException(ATTACH_BOARD_RANGE_OUT);
+//        }
         IntStream.range(0, attachPaths.size())
                 .forEach(
                         idx -> attachBoards.get(idx).update(idx + 1, attachPaths.get(idx))

--- a/src/main/java/com/kakao/saramaracommunity/comment/entity/Comment.java
+++ b/src/main/java/com/kakao/saramaracommunity/comment/entity/Comment.java
@@ -31,13 +31,13 @@ public class Comment extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    private Long pick;
+    private int pick;
 
     @Column(name = "attachment_url")
     private String attachmentUrl;
 
     @Builder
-    private Comment(Member member, Board board, String content, Long pick, String attachmentUrl) {
+    private Comment(Member member, Board board, String content, int pick, String attachmentUrl) {
         this.member = member;
         this.board = board;
         this.content = content;
@@ -45,7 +45,7 @@ public class Comment extends BaseTimeEntity {
         this.attachmentUrl = attachmentUrl;
     }
 
-    public void changeComment(String content, Long pick, String attachmentUrl) {
+    public void changeComment(String content, int pick, String attachmentUrl) {
         this.content = content;
         this.pick = pick;
         this.attachmentUrl = attachmentUrl;

--- a/src/test/java/com/kakao/saramaracommunity/board/entity/AttachBoardTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/board/entity/AttachBoardTest.java
@@ -1,0 +1,65 @@
+package com.kakao.saramaracommunity.board.entity;
+
+import com.kakao.saramaracommunity.member.entity.Member;
+import com.kakao.saramaracommunity.member.entity.Type;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AttachBoardTest {
+
+    @DisplayName("게시글에 등록된 첨부목록 중 하나의 게시글 첨부정보 순서와 객체 URL을 수정한다.")
+    @Test
+    void updateAttachBoard() {
+        // given
+        List<String> attachPaths = List.of("image1.png", "image2.png");
+        Board board = createBoard(createMember(), attachPaths);
+        AttachBoard attachBoard1 = AttachBoard.builder()
+                .board(board)
+                .imageOrder(1)
+                .imagePath(attachPaths.get(0))
+                .build();
+
+        // when
+        attachBoard1.update(1, "image3.png");
+
+        // then
+        assertThat(attachBoard1.getImageOrder()).isEqualTo(1);
+        assertThat(attachBoard1.getImagePath()).isEqualTo("image3.png");
+    }
+
+    @DisplayName("특정 게시글의 첨부 목록")
+    @Test
+    void updateAttachBoards() {
+        // given
+
+        // when
+
+        // then
+    }
+
+
+    private static Member createMember() {
+        return Member.builder()
+                .email("test@test.com")
+                .nickname("test")
+                .password("test")
+                .type(Type.LOCAL)
+                .build();
+    }
+
+    private static Board createBoard(Member member, List<String> attachPaths) {
+        return Board.builder()
+                .title("title")
+                .content("content")
+                .member(member)
+                .categoryBoard(CategoryBoard.CHOICE)
+                .deadLine(LocalDateTime.now())
+                .attachPaths(attachPaths)
+                .build();
+    }
+}

--- a/src/test/java/com/kakao/saramaracommunity/board/entity/AttachBoardTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/board/entity/AttachBoardTest.java
@@ -32,17 +32,6 @@ class AttachBoardTest {
         assertThat(attachBoard1.getImagePath()).isEqualTo("image3.png");
     }
 
-    @DisplayName("특정 게시글의 첨부 목록")
-    @Test
-    void updateAttachBoards() {
-        // given
-
-        // when
-
-        // then
-    }
-
-
     private static Member createMember() {
         return Member.builder()
                 .email("test@test.com")

--- a/src/test/java/com/kakao/saramaracommunity/board/entity/BoardTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/board/entity/BoardTest.java
@@ -9,7 +9,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 
 class BoardTest {
 

--- a/src/test/java/com/kakao/saramaracommunity/board/entity/BoardTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/board/entity/BoardTest.java
@@ -1,0 +1,139 @@
+package com.kakao.saramaracommunity.board.entity;
+
+import com.kakao.saramaracommunity.member.entity.Member;
+import com.kakao.saramaracommunity.member.entity.Type;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+class BoardTest {
+
+    @DisplayName("투표 타입의 게시글 생성시 게시글의 유형은 투표 유형으로 등록된다.")
+    @Test
+    void checkCategoryBoardIsVote() {
+        // given
+        List<String> attachPaths = List.of("image1.png", "image2.png");
+        Member member = createMember();
+
+        // when
+        Board board = Board.builder()
+                .title("title")
+                .content("content")
+                .member(member)
+                .categoryBoard(CategoryBoard.VOTE)
+                .deadLine(LocalDateTime.now())
+                .attachPaths(attachPaths)
+                .build();
+
+        // then
+        assertThat(board.getCategoryBoard()).isEqualTo(CategoryBoard.VOTE);
+    }
+
+    @DisplayName("찬반 타입의 게시글 생성시 게시글의 유형은 찬반 유형으로 등록된다.")
+    @Test
+    void checkCategoryBoardIsChoice() {
+        // given
+        List<String> attachPaths = List.of("image1.png", "image2.png");
+        Member member = createMember();
+
+        // when
+        Board board = Board.builder()
+                .title("title")
+                .content("content")
+                .member(member)
+                .categoryBoard(CategoryBoard.CHOICE)
+                .deadLine(LocalDateTime.now())
+                .attachPaths(attachPaths)
+                .build();
+
+        // then
+        assertThat(board.getCategoryBoard()).isEqualTo(CategoryBoard.CHOICE);
+    }
+
+
+    /**
+     * 게시글 첨부목록 수정 관련 개발 미완료로 인해 임시로 주석 처리했음을 알립니다.
+     */
+
+//    @DisplayName("게시글 제목과 내용만 변경할 경우 변경할 게시글 정보만 변경한다.")
+//    @Test
+//    void updateBoardTitleAndContent() {
+//        // given
+//        List<String> attachPaths = List.of("image1.png", "image2.png");
+//        Member member = createMember();
+//        Board board = Board.builder()
+//                .title("title")
+//                .content("content")
+//                .member(member)
+//                .categoryBoard(CategoryBoard.VOTE)
+//                .deadLine(LocalDateTime.now())
+//                .attachPaths(attachPaths)
+//                .build();
+//
+//        // when
+//        board.update(
+//                "new title",
+//                "content is updated ..",
+//                CategoryBoard.VOTE,
+//                LocalDateTime.now(),
+//                attachPaths
+//        );
+//
+//        // then
+//        assertThat(board.getTitle()).isEqualTo("new title");
+//        assertThat(board.getContent()).isEqualTo("content is updated ..");
+//        assertThat(board.getAttachBoards()).hasSize(2)
+//                .extracting("imagePath")
+//                .containsExactlyInAnyOrder("image1.png", "image2.png");
+//    }
+
+//    @DisplayName("게시글 첨부목록만 변경할 경우 변경할 게시글 정보만 변경한다.")
+//    @Test
+//    void updateBoardAttachBoards() {
+//        // given
+//        List<String> attachPaths = List.of("image1.png", "image2.png");
+//        Member member = createMember();
+//        Board board = Board.builder()
+//                .title("title")
+//                .content("content")
+//                .member(member)
+//                .categoryBoard(CategoryBoard.VOTE)
+//                .deadLine(LocalDateTime.now())
+//                .attachPaths(attachPaths)
+//                .build();
+//        List<String> newAttachPaths = List.of("image1.png", "image2.png", "image3.png");
+//        // when
+//        board.update(
+//                "new title",
+//                "content is updated ..",
+//                CategoryBoard.VOTE,
+//                LocalDateTime.now(),
+//                newAttachPaths
+//        );
+//
+//        // then
+//        assertThat(board.getTitle()).isEqualTo("new title");
+//        assertThat(board.getContent()).isEqualTo("content is updated ..");
+//        assertThat(board.getAttachBoards()).hasSize(3)
+//                .extracting("imageOrder", "imagePath")
+//                .containsExactlyInAnyOrder(
+//                        tuple("image1.png", 1),
+//                        tuple("image2.png", 2),
+//                        tuple("image3.png", 3)
+//                );
+//    }
+
+    private Member createMember() {
+        return Member.builder()
+                .email("test@test.com")
+                .nickname("test")
+                .password("test")
+                .type(Type.LOCAL)
+                .build();
+    }
+}

--- a/src/test/java/com/kakao/saramaracommunity/comment/entity/CommentSetUpTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/comment/entity/CommentSetUpTest.java
@@ -1,0 +1,94 @@
+package com.kakao.saramaracommunity.comment.entity;
+
+import com.kakao.saramaracommunity.board.entity.Board;
+import com.kakao.saramaracommunity.board.entity.CategoryBoard;
+import com.kakao.saramaracommunity.member.entity.Member;
+import com.kakao.saramaracommunity.member.entity.Type;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommentSetUpTest {
+
+    private Member commentWriter;
+    private Board board;
+
+    @BeforeEach
+    void setUp() {
+        // given
+        List<String> attachPaths = List.of("image1.png", "image2.png");
+        Member boardWriter = Member.builder()
+                .email("owner@test.com")
+                .nickname("owner")
+                .password("test")
+                .type(Type.LOCAL)
+                .build();
+        commentWriter = Member.builder()
+                .email("guest@test.com")
+                .nickname("guest")
+                .password("test")
+                .type(Type.LOCAL)
+                .build();
+        board = Board.builder()
+                .title("집에서 잠옷으로 입을 옷을 골라주세요.")
+                .content("content")
+                .member(boardWriter)
+                .categoryBoard(CategoryBoard.VOTE)
+                .deadLine(LocalDateTime.now())
+                .attachPaths(attachPaths)
+                .build();
+    }
+
+    @DisplayName("댓글 작성시 투표하지 않아도 정상적으로 등록된다.")
+    @Test
+    void createCommentWhenPickIsEmpty() {
+        // when
+        Comment comment = Comment.builder()
+                .member(commentWriter)
+                .board(board)
+                .content("저는 수면잠옷을 더 추천드려요..!")
+                .build();
+
+        // then
+        assertThat(comment.getPick()).isZero();
+    }
+
+    @DisplayName("댓글 작성시 첨부파일을 업로드하지 않아도 정상적으로 등록된다.")
+    @Test
+    void createCommentWhenAttachmentIsEmpty() {
+        // when
+        Comment comment = Comment.builder()
+                .member(commentWriter)
+                .board(board)
+                .content("저는 수면잠옷을 더 추천드려요..!")
+                .pick(1)
+                .build();
+
+        // then
+        assertThat(comment.getContent()).isEqualTo("저는 수면잠옷을 더 추천드려요..!");
+    }
+
+    @DisplayName("댓글 수정시 투표를 변경할 수 있다.")
+    @Test
+    void changeCommentPick() {
+        // changeComment for given
+        Comment comment = Comment.builder()
+                .member(commentWriter)
+                .board(board)
+                .content("저는 수면잠옷을 더 추천드려요..!")
+                .pick(1)
+                .build();
+
+        // when
+        comment.changeComment("저는 수면잠옷을 더 추천드려요..!", 3, "");
+
+        // then
+        assertThat(comment.getPick()).isEqualTo(3);
+    }
+
+}

--- a/src/test/java/com/kakao/saramaracommunity/comment/entity/CommentTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/comment/entity/CommentTest.java
@@ -1,0 +1,114 @@
+package com.kakao.saramaracommunity.comment.entity;
+
+import com.kakao.saramaracommunity.board.entity.Board;
+import com.kakao.saramaracommunity.board.entity.CategoryBoard;
+import com.kakao.saramaracommunity.member.entity.Member;
+import com.kakao.saramaracommunity.member.entity.Type;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommentTest {
+
+    @DisplayName("댓글 작성시 투표하지 않아도 정상적으로 등록된다.")
+    @Test
+    void createCommentWhenPickIsEmpty() {
+        // given
+        List<String> attachPaths = List.of("image1.png", "image2.png");
+        Member boardWriter = createMember("owner@test.com", "owner");
+        Member commentWriter = createMember("guest@test.com", "guest");
+        Board board = createBoard(boardWriter, attachPaths);
+
+        // when
+        Comment comment = createCommentWithoutPick(commentWriter, board);
+
+        // then
+        assertThat(comment.getPick()).isZero();
+    }
+
+    @DisplayName("댓글 작성시 첨부파일을 업로드하지 않아도 정상적으로 등록된다.")
+    @Test
+    void createCommentWhenAttachmentIsEmpty() {
+        // given
+        List<String> attachPaths = List.of("image1.png", "image2.png");
+        Member boardWriter = createMember("owner@test.com", "owner");
+        Member commentWriter = createMember("guest@test.com", "guest");
+        Board board = createBoard(boardWriter, attachPaths);
+
+        // when
+        Comment comment = createCommentWithoutAttachment(commentWriter, board);
+
+        // then
+        assertThat(comment.getContent()).isEqualTo("저는 수면잠옷을 더 추천드려요..!");
+    }
+
+    @DisplayName("댓글 수정시 투표를 변경할 수 있다.")
+    @Test
+    void changeCommentPick() {
+        // given
+        List<String> attachPaths = List.of("image1.png", "image2.png");
+        Member boardWriter = createMember("owner@test.com", "owner");
+        Member commentWriter = createMember("guest@test.com", "guest");
+        Board board = createBoard(boardWriter, attachPaths);
+        Comment comment = createComment(commentWriter, board, 1);
+
+        // when
+        comment.changeComment("저는 수면잠옷을 더 추천드려요..!", 3, "");
+
+        // then
+        assertThat(comment.getPick()).isEqualTo(3);
+    }
+
+    private Comment createComment(Member commentWriter, Board board, int pick) {
+        return Comment.builder()
+                .member(commentWriter)
+                .board(board)
+                .content("저는 수면잠옷을 더 추천드려요..!")
+                .pick(pick)
+                .attachmentUrl("attach-url")
+                .build();
+    }
+
+    private Comment createCommentWithoutPick(Member commentWriter, Board board) {
+        return Comment.builder()
+                .member(commentWriter)
+                .board(board)
+                .content("저는 수면잠옷을 더 추천드려요..!")
+                .attachmentUrl("attach-url")
+                .build();
+    }
+
+    private Comment createCommentWithoutAttachment(Member commentWriter, Board board) {
+        return Comment.builder()
+                .member(commentWriter)
+                .board(board)
+                .content("저는 수면잠옷을 더 추천드려요..!")
+                .pick(1)
+                .build();
+    }
+
+    private Board createBoard(Member boardWriter, List<String> attachPaths) {
+        return Board.builder()
+                .title("집에서 잠옷으로 입을 옷을 골라주세요.")
+                .content("이전에 입던 옷이 오래되어서 새 옷을 사야해요.. 부탁합니다 여러분.")
+                .member(boardWriter)
+                .categoryBoard(CategoryBoard.VOTE)
+                .deadLine(LocalDateTime.now())
+                .attachPaths(attachPaths)
+                .build();
+    }
+
+    private Member createMember(String mail, String owner) {
+        return Member.builder()
+                .email(mail)
+                .nickname(owner)
+                .password("test")
+                .type(Type.LOCAL)
+                .build();
+    }
+
+}

--- a/src/test/java/com/kakao/saramaracommunity/comment/entity/CommentTest2.java
+++ b/src/test/java/com/kakao/saramaracommunity/comment/entity/CommentTest2.java
@@ -1,0 +1,93 @@
+package com.kakao.saramaracommunity.comment.entity;
+
+import com.kakao.saramaracommunity.board.entity.Board;
+import com.kakao.saramaracommunity.member.entity.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.kakao.saramaracommunity.fixture.BoardFixture.createBoard;
+import static com.kakao.saramaracommunity.fixture.MemberFixture.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommentTest2 {
+
+    @DisplayName("댓글 작성시 투표하지 않아도 정상적으로 등록된다.")
+    @Test
+    void createCommentWhenPickIsEmpty() {
+        // given
+        List<String> attachPaths = List.of("image1.png", "image2.png");
+        Member boardWriter = createMember("owner@test.com", "owner");
+        Member commentWriter = createMember("guest@test.com", "guest");
+        Board board = createBoard(boardWriter, attachPaths);
+
+        // when
+        Comment comment = createCommentWithoutPick(commentWriter, board);
+
+        // then
+        assertThat(comment.getPick()).isZero();
+    }
+
+    @DisplayName("댓글 작성시 첨부파일을 업로드하지 않아도 정상적으로 등록된다.")
+    @Test
+    void createCommentWhenAttachmentIsEmpty() {
+        // given
+        List<String> attachPaths = List.of("image1.png", "image2.png");
+        Member boardWriter = createMember("owner@test.com", "owner");
+        Member commentWriter = createMember("guest@test.com", "guest");
+        Board board = createBoard(boardWriter, attachPaths);
+
+        // when
+        Comment comment = createCommentWithoutAttachment(commentWriter, board);
+
+        // then
+        assertThat(comment.getContent()).isEqualTo("저는 수면잠옷을 더 추천드려요..!");
+    }
+
+    @DisplayName("댓글 수정시 투표를 변경할 수 있다.")
+    @Test
+    void changeCommentPick() {
+        // given
+        List<String> attachPaths = List.of("image1.png", "image2.png");
+        Member boardWriter = createMember("owner@test.com", "owner");
+        Member commentWriter = createMember("guest@test.com", "guest");
+        Board board = createBoard(boardWriter, attachPaths);
+        Comment comment = createComment(commentWriter, board, 1);
+
+        // when
+        comment.changeComment("저는 수면잠옷을 더 추천드려요..!", 3, "");
+
+        // then
+        assertThat(comment.getPick()).isEqualTo(3);
+    }
+
+    private Comment createComment(Member commentWriter, Board board, int pick) {
+        return Comment.builder()
+                .member(commentWriter)
+                .board(board)
+                .content("저는 수면잠옷을 더 추천드려요..!")
+                .pick(pick)
+                .attachmentUrl("attach-url")
+                .build();
+    }
+
+    private Comment createCommentWithoutPick(Member commentWriter, Board board) {
+        return Comment.builder()
+                .member(commentWriter)
+                .board(board)
+                .content("저는 수면잠옷을 더 추천드려요..!")
+                .attachmentUrl("attach-url")
+                .build();
+    }
+
+    private Comment createCommentWithoutAttachment(Member commentWriter, Board board) {
+        return Comment.builder()
+                .member(commentWriter)
+                .board(board)
+                .content("저는 수면잠옷을 더 추천드려요..!")
+                .pick(1)
+                .build();
+    }
+
+}

--- a/src/test/java/com/kakao/saramaracommunity/fixture/BoardFixture.java
+++ b/src/test/java/com/kakao/saramaracommunity/fixture/BoardFixture.java
@@ -1,0 +1,23 @@
+package com.kakao.saramaracommunity.fixture;
+
+import com.kakao.saramaracommunity.board.entity.Board;
+import com.kakao.saramaracommunity.board.entity.CategoryBoard;
+import com.kakao.saramaracommunity.member.entity.Member;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class BoardFixture {
+
+    public static Board createBoard(Member member, List<String> attachPaths) {
+        return Board.builder()
+                .title("집에서 잠옷으로 입을 옷을 골라주세요.")
+                .content("content")
+                .member(member)
+                .categoryBoard(CategoryBoard.VOTE)
+                .deadLine(LocalDateTime.now())
+                .attachPaths(attachPaths)
+                .build();
+    }
+
+}

--- a/src/test/java/com/kakao/saramaracommunity/fixture/MemberFixture.java
+++ b/src/test/java/com/kakao/saramaracommunity/fixture/MemberFixture.java
@@ -1,0 +1,17 @@
+package com.kakao.saramaracommunity.fixture;
+
+import com.kakao.saramaracommunity.member.entity.Member;
+import com.kakao.saramaracommunity.member.entity.Type;
+
+public class MemberFixture {
+
+    public static Member createMember(String email, String nickname) {
+        return Member.builder()
+                .email(email)
+                .nickname(nickname)
+                .password("test")
+                .type(Type.LOCAL)
+                .build();
+    }
+
+}

--- a/src/test/java/com/kakao/saramaracommunity/fixture/TestFixtures.java
+++ b/src/test/java/com/kakao/saramaracommunity/fixture/TestFixtures.java
@@ -1,0 +1,43 @@
+package com.kakao.saramaracommunity.fixture;
+
+import com.kakao.saramaracommunity.board.entity.Board;
+import com.kakao.saramaracommunity.board.entity.CategoryBoard;
+import com.kakao.saramaracommunity.comment.entity.Comment;
+import com.kakao.saramaracommunity.member.entity.Member;
+import com.kakao.saramaracommunity.member.entity.Type;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class TestFixtures {
+
+    public static Member createMember(String email, String nickname) {
+        return Member.builder()
+                .email(email)
+                .nickname(nickname)
+                .password("test")
+                .type(Type.LOCAL)
+                .build();
+    }
+
+    public static Board createBoard(Member member, List<String> attachPaths) {
+        return Board.builder()
+                .title("집에서 잠옷으로 입을 옷을 골라주세요.")
+                .content("content")
+                .member(member)
+                .categoryBoard(CategoryBoard.VOTE)
+                .deadLine(LocalDateTime.now())
+                .attachPaths(attachPaths)
+                .build();
+    }
+
+    public static Comment createComment(Member member, Board board, int pick) {
+        return Comment.builder()
+                .member(member)
+                .board(board)
+                .content("저는 수면잠옷을 더 추천드려요..!")
+                .pick(pick)
+                .attachmentUrl("attach-url")
+                .build();
+    }
+}


### PR DESCRIPTION
## 🤔 Motivation
- 테스트 케이스마다 필요로하는 Fixture 가이드를 위한 데모 코드 작성

> 이번 PR과 관련된 코드의 흐름이나 목적에 대해서는 [테스트 픽스처를 어떻게 만드는 것이 좋은 걸까?](https://velog.io/@langoustine/Test-Fixture)라는 직접 작성한 글에서 자세히 안내하고 있습니다.

<br>

## 💡 Key Changes

### 테스트 시나리오
- 어떠한 게시글의 댓글을 작성하는 테스트를 한다고 가정한다면, 댓글을 작성할 수 있는 게시글(Board)과 회원(Member)이라는 데이터가 사전에 정의되어야 합니다. 이번 데모 테스트 케이스는 댓글 테스트를 위한 회원과 게시글 데이터인 픽스처를 어떻게 제공하는 것이 좋을지를 전달하려 합니다.

<img width="200" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/59594946/1ea4d56b-3a7c-4da7-a4fb-153b4bf57746">

> 이번에 데모로 사용할 테스트 코드는 위와 같이 test 하위의 comment.entity에 속하는 `CommentSetUpTest`, `CommentTest`, `CommentTest2` 클래스만을 대상으로 진행했음을 알립니다.




<br>

### test 하위의 fixture 패키지

<img width="172" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/59594946/f7086567-97e0-4f7d-99bd-b691ca6108ed">

- fixture 패키지의 TestFixtures 클래스에서는 회원(Member)과 게시글(Board)의 픽스처를 만들어 반환하는 팩토리 메서드를 가집니다. 제공해야 할 픽스처의 개수가 적다면 해당 클래스에서 모든 픽스처를 제공하는 방법도 좋습니다.
- 다만, 제공해야할 픽스처의 개수가 많거나 특정 도메인(엔티티)별로 구분하여 제공하고자 할 때, MemberFixture 및 BoardFixture 클래스처럼 별도의 클래스에서 각각 픽스처를 만들어 제공하도록 구성할 수 있습니다.

<br>

### test 하위의 comment 패키지

<img width="188" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/59594946/1cfb0e16-ba8f-457c-8a48-14b8ef1e047e">

- 해당 패키지의 CommentSetUpTest 클래스는 setUp 메서드에서 픽스처를 초기화하도록 구성한 데모 클래스이며, CommentTest 클래스는 픽스처를 내부 private 메서드로 제공하도록 구성한 데모 클래스입니다. 마지막으로 CommentTest2 클래스는 위의 fixture 패키지에서 제공하는 픽스처를 활용해 픽스처를 세팅하여 테스트하도록 구성한 데모 클래스입니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @byeongJoo05 @IToriginal 

close #100 
