### PR TITLE
[Board/Fix] 게시글 조회수 및 좋아요 관련 로직 제거하기

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/board/entity/Board.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/entity/Board.java
@@ -41,12 +41,6 @@ public class Board extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    @Column(columnDefinition = "integer default 0", nullable = false)
-    private Long viewCount;
-
-    @Column(columnDefinition = "integer default 0", nullable = false)
-    private Long likeCount;
-
     private LocalDateTime deadLine;
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
@@ -58,8 +52,6 @@ public class Board extends BaseTimeEntity {
             CategoryBoard categoryBoard,
             String title,
             String content,
-            Long viewCount,
-            Long likeCount,
             LocalDateTime deadLine,
             List<String> images
     ) {
@@ -67,8 +59,6 @@ public class Board extends BaseTimeEntity {
         this.categoryBoard = categoryBoard;
         this.title = title;
         this.content = content;
-        this.viewCount = viewCount;
-        this.likeCount = likeCount;
         this.deadLine = deadLine;
         this.boardImages = createBoardImages(images);
         validateImageCount(this.categoryBoard, images);
@@ -150,12 +140,6 @@ public class Board extends BaseTimeEntity {
                 throw new BoardBusinessException(BoardErrorCode.BOARD_CHOICE_IMAGE_RANGE_OUT);
             }
         }
-    }
-
-    @PrePersist
-    public void prePersist() {
-        this.viewCount = this.viewCount == null ? 0 : this.viewCount;
-        this.likeCount = this.likeCount == null ? 0 : this.likeCount;
     }
 
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/repository/BoardRepository.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/repository/BoardRepository.java
@@ -24,18 +24,4 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
      */
     List<Board> findByIdLessThanOrderByCreatedAtDesc(Long boardId, Pageable page);
 
-    /**
-     * SELECT * FROM Board
-     * ORDER BY like_cnt DESC
-     * LIMIT :pageSize OFFSET :pageNumber
-     */
-    List<Board> findAllByOrderByLikeCountDesc(Pageable page);
-
-    /**
-     * SELECT * FROM Board
-     * WHERE like_cnt < :likeCnt
-     * ORDER BY like_cnt DESC
-     * LIMIT :pageSize OFFSET :pageNumber
-     */
-    List<Board> findByLikeCountLessThanOrderByLikeCountDesc(Long LikeCnt, Pageable page);
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
@@ -101,23 +101,21 @@ public class BoardServiceImpl implements BoardService {
                 .orElseThrow(() -> new BoardBusinessException(BoardErrorCode.BOARD_NOT_FOUND));
     }
 
+    /**
+     * @param sort 현재는 최신순 정렬(SortType - LATEST(DEFAULT))만 사용되어 파라미터의 sort는 사용되지 않음.
+     */
     private Long getNextCursorId(SortType sort, List<Board> boards) {
-        return boards.isEmpty() ?
-                null : SortType.POPULAR.equals(sort) ?
-                boards.get(boards.size() - 1).getLikeCount() : boards.get(boards.size() - 1).getId();
+        return boards.isEmpty() ? null : boards.get(boards.size() - 1).getId();
     }
 
+    /**
+     * @param sort 현재는 최신순 정렬(SortType - LATEST(DEFAULT))만 사용되어 파라미터의 sort는 사용되지 않음.
+     */
     private List<Board> getBoards(Long cursorId, Pageable page, SortType sort) {
-        if (SortType.POPULAR.equals(sort)) {
-            log.info("[BoardServiceImpl] 인기순으로 게시글을 조회합니다.(Reading all boards by popularity)");
-            return cursorId == null ?
-                    boardRepository.findAllByOrderByLikeCountDesc(page) :
-                    boardRepository.findByLikeCountLessThanOrderByLikeCountDesc(cursorId, page);
-        } else {
-            log.info("[BoardServiceImpl] 최신순으로 게시글을 조회합니다.(Reading all boards by latest)");
-            return cursorId == null ?
-                    boardRepository.findAllByOrderByCreatedAtDesc(page) :
-                    boardRepository.findByIdLessThanOrderByCreatedAtDesc(cursorId, page);
-        }
+        log.info("[BoardServiceImpl] 최신순으로 게시글을 조회합니다.(Reading all boards by latest)");
+        return cursorId == null ?
+                boardRepository.findAllByOrderByCreatedAtDesc(page) :
+                boardRepository.findByIdLessThanOrderByCreatedAtDesc(cursorId, page);
     }
+
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/service/dto/response/BoardResponse.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/dto/response/BoardResponse.java
@@ -21,8 +21,6 @@ public class BoardResponse {
         private final CategoryBoard categoryBoard;
         private final String writer;
         private final String memberEmail;
-        private final Long viewCount;
-        private final Long likeCount;
         private final LocalDateTime deadLine;
         private final List<String> boardImages;
 
@@ -34,8 +32,6 @@ public class BoardResponse {
                 CategoryBoard categoryBoard,
                 String writer,
                 String memberEmail,
-                Long viewCount,
-                Long likeCount,
                 LocalDateTime deadLine,
                 List<String> boardImages
         ) {
@@ -45,8 +41,6 @@ public class BoardResponse {
             this.categoryBoard = categoryBoard;
             this.writer = writer;
             this.memberEmail = memberEmail;
-            this.viewCount = viewCount;
-            this.likeCount = likeCount;
             this.deadLine = deadLine;
             this.boardImages = boardImages;
         }
@@ -59,8 +53,6 @@ public class BoardResponse {
                     .categoryBoard(board.getCategoryBoard())
                     .writer(board.getMember().getNickname())
                     .memberEmail(board.getMember().getEmail())
-                    .viewCount(board.getViewCount())
-                    .likeCount(board.getLikeCount())
                     .deadLine(board.getDeadLine())
                     .boardImages(board.getBoardImages().stream().
                             map(BoardImage::getPath)
@@ -103,8 +95,6 @@ public class BoardResponse {
         private final String content;
         private final CategoryBoard categoryBoard;
         private final String writer;
-        private final Long viewCount;
-        private final Long likeCount;
         private final LocalDateTime deadLine;
         private final List<String> boardImages;
 
@@ -115,8 +105,6 @@ public class BoardResponse {
                 String content,
                 CategoryBoard categoryBoard,
                 String writer,
-                Long viewCount,
-                Long likeCount,
                 LocalDateTime deadLine,
                 List<String> boardImages
         ) {
@@ -125,8 +113,6 @@ public class BoardResponse {
             this.content = content;
             this.categoryBoard = categoryBoard;
             this.writer = writer;
-            this.viewCount = viewCount;
-            this.likeCount = likeCount;
             this.deadLine = deadLine;
             this.boardImages = boardImages;
         }
@@ -138,8 +124,6 @@ public class BoardResponse {
                     .content(board.getContent())
                     .categoryBoard(board.getCategoryBoard())
                     .writer(board.getMember().getNickname())
-                    .viewCount(board.getViewCount())
-                    .likeCount(board.getLikeCount())
                     .deadLine(board.getDeadLine())
                     .boardImages(board.getBoardImages().stream()
                             .map(BoardImage::getPath)


### PR DESCRIPTION
## 🤔 Motivation
- 게시글 도메인 관련 사용하지 않는 필드 및 로직을 제거하였습니다.

<br>

## 💡 Key Changes
1. 게시글 조회수(`viewCount`), 게시글 좋아요(`likeCount`) 필드를 제거하였습니다.(`BoardResponse` 응답 DTO 클래스 필드 포함)
- 연관된 `BoardRepository` 인터페이스에 `findAllByOrderByLikeCountDesc`, `findByLikeCountLessThanOrderByLikeCountDesc` 메서드를 제거하였습니다.
2. 개발 방향 변경에 따른 인기순 정렬 로직 제거
- 페이지네이션 처리를 위해 개발되었던 `getNextCursorId` 메서드와 `getBoards` 메서드에 "인기순 정렬일 경우" 진행되는 비즈니스 로직을 제거하였습니다.
- 단, `SortType`에 대해서는 추후 추가될 가능성이 높기 때문에 제거하지 않았습니다.
- 해당 클래스(`SortType`)의 보존 여부는 투표 도메인을 개발하며 재논의해보면 좋을 것 같습니다. (SortType에 존재하는 POPULAR 필드는 투표 도메인이 개발되고 판단해도 될 것 같습니다.)

### ✅ Test Check
아래의 이미지와 같이 이번 이슈로 인한 단위 테스트와 통합 테스트에 `이상 없음`을 확인하였습니다.
<img width="686" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/117193889/6b833f59-3ab7-4855-b310-67fade9759dc">

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @langoustinee @byeongJoo05 
- 위의 내용에 대한 피드백 부탁드립니다.
- 추가적으로 개선할 수 있는 부분이나 주의해야 할 사항이 있다면 알려주시면 감사하겠습니다.

close #122