### PR TITLE
[Feat] 게시글 단위 테스트(BoardTest)에 DCI 패턴 도입하기

### DIFF
--- a/src/test/java/com/kakao/saramaracommunity/board/entity/BoardTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/board/entity/BoardTest.java
@@ -1,12 +1,8 @@
 package com.kakao.saramaracommunity.board.entity;
 
 import com.kakao.saramaracommunity.board.exception.BoardBusinessException;
-import com.kakao.saramaracommunity.board.exception.BoardErrorCode;
-import com.kakao.saramaracommunity.fixture.MemberFixture;
 import com.kakao.saramaracommunity.member.entity.Member;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,9 +11,11 @@ import java.util.stream.IntStream;
 
 import static com.kakao.saramaracommunity.board.entity.CategoryBoard.CHOICE;
 import static com.kakao.saramaracommunity.board.entity.CategoryBoard.VOTE;
+import static com.kakao.saramaracommunity.board.exception.BoardErrorCode.*;
 import static com.kakao.saramaracommunity.fixture.MemberFixture.NORMAL_MEMBER_LANGO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 /**
  * 게시글(Board) 관련 도메인의 단위 테스트를 진행하는 테스트 클래스입니다.
@@ -25,288 +23,277 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class BoardTest {
 
-    @DisplayName("찬반 타입의 게시글 생성 시, 찬반 카테고리의 게시글로 등록된다.")
-    @Test
-    void create_Board_With_Category_Is_Choice() {
-        // given
-        Member NORMAL_MEMBER = MemberFixture.NORMAL_MEMBER_LANGO.createMember();
-        List<String> images = createImagePaths(1);
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 게시글_생성_시 {
+        private Member NORMAL_MEMBER;
+        @BeforeEach
+        void setUp() {
+            NORMAL_MEMBER = NORMAL_MEMBER_LANGO.createMember();
+        }
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 투표_카테고리일_경우 {
+            @Test
+            @DisplayName("이미지는 최소 2장 이상 등록해야 한다.")
+            void 이미지는_최소_2장_이상_등록해야_한다() {
+                // given
+                List<String> images = createImagePaths(3);
 
-        // when
-        Board board = createBoard(NORMAL_MEMBER, images, CHOICE);
+                // when
+                Board result = createBoard(NORMAL_MEMBER, images, VOTE);
 
-        // then
-        assertThat(board.getCategoryBoard()).isSameAs(CHOICE);
+                // then
+                assertThat(result.getBoardImages()).hasSize(3);
+            }
+            @Test
+            @DisplayName("등록한 이미지가 1장일 경우 예외가 발생한다.")
+            void 등록한_이미지가_1장일_경우_예외가_발생한다() {
+                // given
+                List<String> images = createImagePaths(1);
+
+                // when & then
+                assertThatThrownBy(() -> createBoard(NORMAL_MEMBER, images, VOTE))
+                        .isInstanceOf(BoardBusinessException.class)
+                        .hasMessage(BOARD_VOTE_IMAGE_RANGE_OUT.getMessage());
+            }
+            @Test
+            @DisplayName("등록한 이미지가 5장을 초과할 경우 예외가 발생한다.")
+            void 등록한_이미지가_5장을_초과할_경우_예외가_발생한다() {
+                // given
+                List<String> images = createImagePaths(6);
+
+                // when & then
+                assertThatThrownBy(() -> createBoard(NORMAL_MEMBER, images, VOTE))
+                        .isInstanceOf(BoardBusinessException.class)
+                        .hasMessage(BOARD_VOTE_IMAGE_RANGE_OUT.getMessage());
+            }
+        }
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 찬반_카테고리일_경우 {
+            @Test
+            @DisplayName("이미지는 1장만 등록할 수 있다.")
+            void 이미지는_1장만_등록할_수_있다() {
+                // given
+                List<String> images = createImagePaths(1);
+
+                // when
+                Board result = createBoard(NORMAL_MEMBER, images, CHOICE);
+
+                // then
+                assertThat(result.getBoardImages()).hasSize(1);
+            }
+            @Test
+            @DisplayName("등록한 이미지가 1장을 초과할 경우 예외가 발생한다.")
+            void 등록한_이미지가_1장을_초과할_경우_예외가_발생한다() {
+                // given
+                List<String> images = createImagePaths(2);
+
+                // when & then
+                assertThatThrownBy(() -> createBoard(NORMAL_MEMBER, images, CHOICE))
+                        .isInstanceOf(BoardBusinessException.class)
+                        .hasMessage(BOARD_CHOICE_IMAGE_RANGE_OUT.getMessage());
+            }
+        }
     }
 
-    @DisplayName("찬반 타입의 게시글을 생성 시, 이미지를 2장 이상 등록한다면 예외가 발생한다.")
-    @Test
-    void create_Board_With_Category_Is_Choice_When_Two_Images() {
-        // given
-        Member NORMAL_MEMBER = MemberFixture.NORMAL_MEMBER_LANGO.createMember();
-        List<String> images = createImagePaths(2);
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 게시글_수정_시 {
+        private Member NORMAL_MEMBER;
+        @BeforeEach
+        void setUp() {
+            NORMAL_MEMBER = NORMAL_MEMBER_LANGO.createMember();
+        }
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 작성자_라면 {
+            @Nested
+            @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+            class 투표_카테고리의_글을_수정할_때 {
+                @Test
+                @DisplayName("이미지는 최대 5장까지 추가할 수 있다.")
+                void 이미지는_최대_5장까지_추가할_수_있다() {
+                    // given
+                    List<String> images = createImagePaths(3);
+                    Board board = createBoard(NORMAL_MEMBER, images, VOTE);
+                    setField(NORMAL_MEMBER, "memberId", 1L);
 
-        // when & then
-        assertThatThrownBy(() -> createBoard(NORMAL_MEMBER, images, CHOICE))
-                .isInstanceOf(BoardBusinessException.class)
-                .hasMessage(BoardErrorCode.BOARD_CHOICE_IMAGE_RANGE_OUT.getMessage());
-    }
+                    // when
+                    List<String> updateImages = createImagePaths(5);
+                    board.update(
+                            NORMAL_MEMBER.getMemberId(),
+                            "update-title",
+                            "update-content",
+                            VOTE,
+                            LocalDateTime.now(),
+                            updateImages
+                    );
 
-    @DisplayName("투표 타입의 게시글 생성시 투표 카테고리의 게시글로 등록된다.")
-    @Test
-    void create_Board_With_Category_Is_Vote() {
-        // given
-        Member NORMAL_MEMBER = NORMAL_MEMBER_LANGO.createMember();
-        List<String> images = createImagePaths(3);
+                    // then
+                    assertThat(board.getTitle()).isEqualTo("update-title");
+                    assertThat(board.getContent()).isEqualTo("update-content");
+                    assertThat(board.getBoardImages()).hasSize(5)
+                            .extracting("path")
+                            .containsExactlyInAnyOrder(
+                                    "s3-image-path-1",
+                                    "s3-image-path-2",
+                                    "s3-image-path-3",
+                                    "s3-image-path-4",
+                                    "s3-image-path-5"
+                            );
+                }
+                @Test
+                @DisplayName("추가한 이미지가 5장을 초과할 경우 예외가 발생한다.")
+                void 추가한_이미지가_5장을_초과할_경우_예외가_발생한다() {
+                    // given
+                    List<String> images = createImagePaths(3);
+                    Board board = createBoard(NORMAL_MEMBER, images, VOTE);
+                    setField(NORMAL_MEMBER, "memberId", 1L);
 
-        // when
-        Board board = createBoard(NORMAL_MEMBER, images, VOTE);
+                    // when & then
+                    List<String> updateImages = createImagePaths(6);
+                    assertThatThrownBy(() -> board.update(
+                            NORMAL_MEMBER.getMemberId(),
+                            "update-title",
+                            "update-content",
+                            VOTE,
+                            LocalDateTime.now(),
+                            updateImages
+                    ))
+                            .isInstanceOf(BoardBusinessException.class)
+                            .hasMessage(BOARD_VOTE_IMAGE_RANGE_OUT.getMessage());
+                }
+                @Test
+                @DisplayName("이미지는 2장까지만 삭제할 수 있다.")
+                void 이미지는_2장까지만_삭제할_수_있다() {
+                    // given
+                    List<String> images = createImagePaths(3);
+                    Board board = createBoard(NORMAL_MEMBER, images, VOTE);
+                    setField(NORMAL_MEMBER, "memberId", 1L);
 
-        // then
-        assertThat(board.getCategoryBoard()).isEqualTo(VOTE);
-    }
+                    // when
+                    List<String> updateImages = createImagePaths(2);
+                    board.update(
+                            NORMAL_MEMBER.getMemberId(),
+                            "update-title",
+                            "update-content",
+                            VOTE,
+                            LocalDateTime.now(),
+                            updateImages
+                    );
 
-    @DisplayName("투표 타입의 게시글을 생성 시, 1장의 이미지만 등록했다면 예외가 발생한다.")
-    @Test
-    void create_Board_With_Category_Is_Vote_When_One_Images() {
-        // given
-        Member NORMAL_MEMBER = MemberFixture.NORMAL_MEMBER_LANGO.createMember();
-        List<String> images = createImagePaths(1);
+                    // then
+                    assertThat(board.getTitle()).isEqualTo("update-title");
+                    assertThat(board.getBoardImages()).hasSize(2)
+                            .extracting("path")
+                            .containsExactlyInAnyOrder(
+                                    "s3-image-path-1",
+                                    "s3-image-path-2"
+                            );
+                }
+                @Test
+                @DisplayName("이미지를 2장 미만으로 삭제할 경우 예외가 발생한다.")
+                void 이미지를_2장_미만으로_삭제할_경우_예외가_발생한다() {
+                    // given
+                    List<String> images = createImagePaths(3);
+                    Board board = createBoard(NORMAL_MEMBER, images, VOTE);
+                    setField(NORMAL_MEMBER, "memberId", 1L);
 
-        // when & then
-        assertThatThrownBy(() -> createBoard(NORMAL_MEMBER, images, VOTE))
-                .isInstanceOf(BoardBusinessException.class)
-                .hasMessage(BoardErrorCode.BOARD_VOTE_IMAGE_RANGE_OUT.getMessage());
-    }
+                    // when & then
+                    List<String> updateImages = createImagePaths(1);
+                    assertThatThrownBy(() -> board.update(
+                            NORMAL_MEMBER.getMemberId(),
+                            "update-title",
+                            "update-content",
+                            VOTE,
+                            LocalDateTime.now(),
+                            updateImages
+                    ))
+                            .isInstanceOf(BoardBusinessException.class)
+                            .hasMessage(BOARD_VOTE_IMAGE_RANGE_OUT.getMessage());
+                }
+            }
+            @Nested
+            @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+            class 찬반_카테고리의_글을_수정할_때 {
+                @Test
+                @DisplayName("등록한 이미지 1장만 변경할 수 있다.")
+                void 등록한_이미지_1장만_변경할_수_있다() {
+                    // given
+                    List<String> images = createImagePaths(1);
+                    Board board = createBoard(NORMAL_MEMBER, images, CHOICE);
+                    setField(NORMAL_MEMBER, "memberId", 1L);
 
-    @DisplayName("투표 타입의 게시글을 생성 시, 이미지를 5장 초과하여 등록했다면 예외가 발생한다.")
-    @Test
-    void create_Board_With_Category_Is_Vote_When_Over_Five_Images() {
-        // given
-        Member NORMAL_MEMBER = MemberFixture.NORMAL_MEMBER_LANGO.createMember();
-        List<String> images = createImagePaths(6);
+                    // when
+                    List<String> updateImages = createImagePaths(1);
+                    board.update(
+                            NORMAL_MEMBER.getMemberId(),
+                            "update-title",
+                            "update-content",
+                            board.getCategoryBoard(),
+                            LocalDateTime.now(),
+                            updateImages
+                    );
 
-        // when & then
-        assertThatThrownBy(() -> createBoard(NORMAL_MEMBER, images, VOTE))
-                .isInstanceOf(BoardBusinessException.class)
-                .hasMessage(BoardErrorCode.BOARD_VOTE_IMAGE_RANGE_OUT.getMessage());
-    }
+                    // then
+                    assertThat(board.getTitle()).isEqualTo("update-title");
+                    assertThat(board.getBoardImages()).hasSize(1)
+                            .extracting("path")
+                            .containsExactlyInAnyOrder(
+                                    "s3-image-path-1"
+                            );
+                }
+                @Test
+                @DisplayName("추가한 이미지가 1장을 초과할 경우 예외가 발생한다.")
+                void 추가한_이미지가_1장을_초과할_경우_예외가_발생한다() {
+                    // given
+                    List<String> images = createImagePaths(1);
+                    Board board = createBoard(NORMAL_MEMBER, images, CHOICE);
+                    setField(NORMAL_MEMBER, "memberId", 1L);
 
-    @DisplayName("찬반 타입의 게시글을 수정할 때, 이미지를 새로 추가한다.")
-    @Test
-    void update_Board_With_Category_Is_Choice_New_Image() {
-        // given
-        Member NORMAL_MEMBER = NORMAL_MEMBER_LANGO.createMember();
-        List<String> images = createImagePaths(1);
-        Board board = createBoard(NORMAL_MEMBER, images, CHOICE);
-        ReflectionTestUtils.setField(NORMAL_MEMBER, "memberId", 1L);
+                    // when & then
+                    List<String> updateImages = createImagePaths(3);
+                    assertThatThrownBy(() -> board.update(
+                            NORMAL_MEMBER.getMemberId(),
+                            "update-title",
+                            "update-content",
+                            board.getCategoryBoard(),
+                            LocalDateTime.now(),
+                            updateImages
+                    ))
+                            .isInstanceOf(BoardBusinessException.class)
+                            .hasMessage(BOARD_CHOICE_IMAGE_RANGE_OUT.getMessage());
+                }
+            }
+        }
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 작성자가_아니라면 {
+            @Test
+            @DisplayName("수정할 수 없다.")
+            void 수정할_수_없다() {
+                // given
+                Member NORMAL_MEMBER_NOT_WRITER = NORMAL_MEMBER_LANGO.createMember();
+                List<String> images = createImagePaths(3);
+                Board board = createBoard(NORMAL_MEMBER, images, VOTE);
+                setField(NORMAL_MEMBER, "memberId", 1L);
+                setField(NORMAL_MEMBER_NOT_WRITER, "memberId", 2L);
 
-        // when
-        List<String> updateImages = createImagePaths(1);
-        board.update(
-                NORMAL_MEMBER.getMemberId(),
-                "update-title",
-                "update-content",
-                board.getCategoryBoard(),
-                LocalDateTime.now(),
-                updateImages
-        );
-
-        // then
-        assertThat(board.getTitle()).isEqualTo("update-title");
-        assertThat(board.getBoardImages()).hasSize(1)
-                .extracting("path")
-                .containsExactlyInAnyOrder(
-                        "s3-image-path-1"
-                );
-    }
-
-    @DisplayName("찬반 타입의 게시글을 수정할 때, 이미지는 반드시 1장이어야 한다.")
-    @Test
-    void update_Board_With_Category_Is_Choice_When_Over_One_Image() {
-        // given
-        Member NORMAL_MEMBER = NORMAL_MEMBER_LANGO.createMember();
-        List<String> images = createImagePaths(1);
-        Board board = createBoard(NORMAL_MEMBER, images, CHOICE);
-        ReflectionTestUtils.setField(NORMAL_MEMBER, "memberId", 1L);
-
-        // when & then
-        List<String> updateImages = createImagePaths(3);
-        assertThatThrownBy(() -> board.update(
-                NORMAL_MEMBER.getMemberId(),
-                "update-title",
-                "update-content",
-                board.getCategoryBoard(),
-                LocalDateTime.now(),
-                updateImages
-        ))
-                .isInstanceOf(BoardBusinessException.class)
-                .hasMessage(BoardErrorCode.BOARD_CHOICE_IMAGE_RANGE_OUT.getMessage());
-    }
-
-    @DisplayName("투표 타입의 게시글을 수정할 때, 이미지 1장을 새로 추가한다.")
-    @Test
-    void update_Board_With_Category_Is_Vote_New_Image() {
-        // given
-        Member NORMAL_MEMBER = NORMAL_MEMBER_LANGO.createMember();
-        List<String> images = createImagePaths(3);
-        Board board = createBoard(NORMAL_MEMBER, images, VOTE);
-        ReflectionTestUtils.setField(NORMAL_MEMBER, "memberId", 1L);
-
-        // when
-        List<String> updateImages = createImagePaths(4);
-        board.update(
-                NORMAL_MEMBER.getMemberId(),
-                "update-title",
-                "update-content",
-                VOTE,
-                LocalDateTime.now(),
-                updateImages
-        );
-
-        // then
-        assertThat(board.getTitle()).isEqualTo("update-title");
-        assertThat(board.getBoardImages()).hasSize(4)
-                .extracting("path")
-                .containsExactlyInAnyOrder(
-                        "s3-image-path-1",
-                        "s3-image-path-2",
-                        "s3-image-path-3",
-                        "s3-image-path-4"
-                );
-    }
-
-    @DisplayName("투표 타입의 게시글을 수정할 때, 이미지 2장을 새로 추가한다.")
-    @Test
-    void update_Board_With_Category_Is_Vote_New_Two_Image() {
-        // given
-        Member NORMAL_MEMBER = NORMAL_MEMBER_LANGO.createMember();
-        List<String> images = createImagePaths(3);
-        Board board = createBoard(NORMAL_MEMBER, images, VOTE);
-        ReflectionTestUtils.setField(NORMAL_MEMBER, "memberId", 1L);
-
-        // when
-        List<String> updateImages = createImagePaths(5);
-        board.update(
-                NORMAL_MEMBER.getMemberId(),
-                "update-title",
-                "update-content",
-                VOTE,
-                LocalDateTime.now(),
-                updateImages
-        );
-
-        // then
-        assertThat(board.getTitle()).isEqualTo("update-title");
-        assertThat(board.getBoardImages()).hasSize(5)
-                .extracting("path")
-                .containsExactlyInAnyOrder(
-                        "s3-image-path-1",
-                        "s3-image-path-2",
-                        "s3-image-path-3",
-                        "s3-image-path-4",
-                        "s3-image-path-5"
-                );
-    }
-
-    @DisplayName("투표 타입의 게시글을 수정하여 이미지를 새로 추가할 때, 5장을 초과하면 예외가 발생한다.")
-    @Test
-    void update_Board_With_Category_Is_Vote_When_Over_Five_Images() {
-        // given
-        Member NORMAL_MEMBER = NORMAL_MEMBER_LANGO.createMember();
-        List<String> images = createImagePaths(3);
-        Board board = createBoard(NORMAL_MEMBER, images, VOTE);
-        ReflectionTestUtils.setField(NORMAL_MEMBER, "memberId", 1L);
-
-        // when & then
-        List<String> updateImages = createImagePaths(6);
-        assertThatThrownBy(() -> board.update(
-                NORMAL_MEMBER.getMemberId(),
-                "update-title",
-                "update-content",
-                VOTE,
-                LocalDateTime.now(),
-                updateImages
-        ))
-                .isInstanceOf(BoardBusinessException.class)
-                .hasMessage(BoardErrorCode.BOARD_VOTE_IMAGE_RANGE_OUT.getMessage());
-    }
-
-    @DisplayName("투표 타입의 게시글을 수정할 때, 이미지 1장을 삭제한다.")
-    @Test
-    void update_Board_With_Category_Is_Vote_Out_Images() {
-        // given
-        Member NORMAL_MEMBER = NORMAL_MEMBER_LANGO.createMember();
-        List<String> images = createImagePaths(3);
-        Board board = createBoard(NORMAL_MEMBER, images, VOTE);
-        ReflectionTestUtils.setField(NORMAL_MEMBER, "memberId", 1L);
-
-        // when
-        List<String> updateImages = createImagePaths(2);
-        board.update(
-                NORMAL_MEMBER.getMemberId(),
-                "update-title",
-                "update-content",
-                VOTE,
-                LocalDateTime.now(),
-                updateImages
-        );
-
-        // then
-        assertThat(board.getTitle()).isEqualTo("update-title");
-        assertThat(board.getBoardImages()).hasSize(2)
-                .extracting("path")
-                .containsExactlyInAnyOrder(
-                        "s3-image-path-1",
-                        "s3-image-path-2"
-                );
-    }
-
-    @DisplayName("투표 타입의 게시글을 수정하여 이미지를 삭제했을 때, 2장 미만이 되면 예외가 발생한다.")
-    @Test
-    void update_Board_With_Category_Is_Vote_Out_Two_Images() {
-        // given
-        Member NORMAL_MEMBER = NORMAL_MEMBER_LANGO.createMember();
-        List<String> images = createImagePaths(3);
-        Board board = createBoard(NORMAL_MEMBER, images, VOTE);
-        ReflectionTestUtils.setField(NORMAL_MEMBER, "memberId", 1L);
-
-        // when & then
-        List<String> updateImages = createImagePaths(1);
-        assertThatThrownBy(() -> board.update(
-                NORMAL_MEMBER.getMemberId(),
-                "update-title",
-                "update-content",
-                VOTE,
-                LocalDateTime.now(),
-                updateImages
-        ))
-                .isInstanceOf(BoardBusinessException.class)
-                .hasMessage(BoardErrorCode.BOARD_VOTE_IMAGE_RANGE_OUT.getMessage());
-    }
-
-    @DisplayName("게시글을 수정할 때, 다른 사용자가 게시글을 수정할 수 없다.")
-    @Test
-    void update_Board_Only_Same_Writer() {
-        // given
-        Member MEMBER_LANGO = NORMAL_MEMBER_LANGO.createMember();
-        Member MEMBER_SONNY = NORMAL_MEMBER_LANGO.createMember();
-        List<String> images = createImagePaths(3);
-        Board board = createBoard(MEMBER_LANGO, images, VOTE);
-        ReflectionTestUtils.setField(MEMBER_LANGO, "memberId", 1L);
-        ReflectionTestUtils.setField(MEMBER_SONNY, "memberId", 2L);
-
-        // when & then
-        assertThatThrownBy(() -> board.update(
-                MEMBER_SONNY.getMemberId(),
-                "update-title",
-                "update-content",
-                VOTE,
-                LocalDateTime.now(),
-                images
-        ))
-                .isInstanceOf(BoardBusinessException.class)
-                .hasMessage(BoardErrorCode.UNAUTHORIZED_TO_UPDATE_BOARD.getMessage());
+                // when & then
+                assertThatThrownBy(() -> board.update(
+                        NORMAL_MEMBER_NOT_WRITER.getMemberId(),
+                        "update-title",
+                        "update-content",
+                        VOTE,
+                        LocalDateTime.now(),
+                        images
+                ))
+                        .isInstanceOf(BoardBusinessException.class)
+                        .hasMessage(UNAUTHORIZED_TO_UPDATE_BOARD.getMessage());
+            }
+        }
     }
 
     private static Board createBoard(


### PR DESCRIPTION
## 🤔 Motivation
- 게시글(Board) 단위 테스트에 DCI 패턴 적용하여 테스트 가독성 향상시키기

<br>

## 💡 Key Changes
> 본래 통합 테스트외 더불어 게시글 전 계층 테스트에 모두 DCI 패턴을 적용한 후 PR 하려했으나, 팀원분들의 단위 테스트 가이드 코드가 필요할 것 같아 먼저 BoardTest 따로 병합을 요청드립니다..!

- 기존의 게시글 단위 테스트는 BDD의 Given-When-Then 방식으로 작성되어 있어, 테스트 수행 결과가 한눈에 들어오지 않았습니다.
- 이러한 부분을 개선하고자 DCI 패턴을 도입하여 계층구조의 테스트 코드로 수정했고, 테스트 수행결과를 계층화된 상태로 볼 수 있어 가독성이 늘어났습니다.
- 테스트 케이스의 가독성이 늘어났을 뿐만 아니라, 영어로 작성해야 했던 메소드 명명 시간을 줄일 수 있어 생산성 향상에 도움이 되었습니다.
- 단위 테스트에 무조건 DCI 패턴을 사용해야 하는 것은 아니지만, 계층 구조로 테스트를 작성해야 할 경우 해당 코드를 가이드삼아 참고했으면 좋겠습니다..! 물론 BoardTest 또한 계속해서 리팩토링할 계획입니다.

> 이번 PR과 관련하여 [기록한 글](https://velog.io/@langoustine/DCI%ED%8C%A8%ED%84%B4-%ED%85%8C%EC%8A%A4%ED%8A%B8%EA%B0%80%EB%8F%85%EC%84%B1-%ED%96%A5%EC%83%81)을 참고하시기 바랍니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @byeongJoo05 @IToriginal 

#120 