### PR TITLE
[Fix] 누락된 ReplaceUnderscores 수정하기

### DIFF
--- a/src/test/java/com/kakao/saramaracommunity/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/board/controller/BoardControllerTest.java
@@ -4,9 +4,8 @@ import com.kakao.saramaracommunity.board.dto.api.reqeust.BoardCreateRequest;
 import com.kakao.saramaracommunity.board.dto.api.reqeust.BoardDeleteRequest;
 import com.kakao.saramaracommunity.board.dto.api.reqeust.BoardUpdateRequest;
 import com.kakao.saramaracommunity.support.ControllerTestSupport;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 
 import java.time.LocalDateTime;
@@ -26,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class BoardControllerTest extends ControllerTestSupport {
 
     @Nested
-    @DisplayName("새로운 게시글 생성 시")
+    @DisplayNameGeneration(ReplaceUnderscores.class)
     class 새로운_게시글_생성_시 {
         @Test
         @DisplayName("정상적으로 등록할 수 있다.")
@@ -178,7 +177,7 @@ class BoardControllerTest extends ControllerTestSupport {
     }
     
     @Nested
-    @DisplayName("게시글 수정 시")
+    @DisplayNameGeneration(ReplaceUnderscores.class)
     class 게시글_수정_시 {
         @Test
         @DisplayName("정상적으로 변경할 수 있다.")
@@ -378,7 +377,7 @@ class BoardControllerTest extends ControllerTestSupport {
     }
 
     @Nested
-    @DisplayName("게시글 삭제 시")
+    @DisplayNameGeneration(ReplaceUnderscores.class)
     class 게시글_삭제_시 {
         @Test
         @DisplayName("정상적으로 삭제할 수 있다.")

--- a/src/test/java/com/kakao/saramaracommunity/board/entity/BoardTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/board/entity/BoardTest.java
@@ -4,6 +4,7 @@ import com.kakao.saramaracommunity.board.exception.BoardBusinessException;
 import com.kakao.saramaracommunity.member.entity.Member;
 import com.kakao.saramaracommunity.member.exception.MemberBusinessException;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -25,7 +26,7 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 class BoardTest {
 
     @Nested
-    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    @DisplayNameGeneration(ReplaceUnderscores.class)
     class 게시글_생성_시 {
         private Member NORMAL_MEMBER;
         @BeforeEach
@@ -33,7 +34,7 @@ class BoardTest {
             NORMAL_MEMBER = NORMAL_MEMBER_LANGO.createMember();
         }
         @Nested
-        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        @DisplayNameGeneration(ReplaceUnderscores.class)
         class 투표_카테고리일_경우 {
             @Test
             @DisplayName("이미지는 최소 2장 이상 등록해야 한다.")
@@ -60,7 +61,7 @@ class BoardTest {
             }
         }
         @Nested
-        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        @DisplayNameGeneration(ReplaceUnderscores.class)
         class 찬반_카테고리일_경우 {
             @Test
             @DisplayName("이미지는 1장만 등록할 수 있다.")
@@ -89,7 +90,7 @@ class BoardTest {
     }
 
     @Nested
-    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    @DisplayNameGeneration(ReplaceUnderscores.class)
     class 게시글_수정_시 {
         private Member NORMAL_MEMBER;
         @BeforeEach
@@ -98,7 +99,7 @@ class BoardTest {
             setField(NORMAL_MEMBER, "id", 1L);
         }
         @Nested
-        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        @DisplayNameGeneration(ReplaceUnderscores.class)
         class 작성자_라면 {
             @Test
             @DisplayName("글 제목을 변경할 수 있다.")
@@ -165,7 +166,7 @@ class BoardTest {
             }
 
             @Nested
-            @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+            @DisplayNameGeneration(ReplaceUnderscores.class)
             class 투표_카테고리의_글을_수정할_때 {
                 @Test
                 @DisplayName("이미지는 최대 5장까지 추가할 수 있다.")
@@ -276,7 +277,7 @@ class BoardTest {
                 }
             }
             @Nested
-            @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+            @DisplayNameGeneration(ReplaceUnderscores.class)
             class 찬반_카테고리의_글을_수정할_때 {
                 @Test
                 @DisplayName("등록한 이미지 1장만 변경할 수 있다.")
@@ -327,7 +328,7 @@ class BoardTest {
             }
         }
         @Nested
-        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        @DisplayNameGeneration(ReplaceUnderscores.class)
         class 작성자가_아니라면 {
             @Test
             @DisplayName("수정할 수 없다.")

--- a/src/test/java/com/kakao/saramaracommunity/board/service/BoardServiceImplTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/board/service/BoardServiceImplTest.java
@@ -16,6 +16,7 @@ import com.kakao.saramaracommunity.member.exception.MemberBusinessException;
 import com.kakao.saramaracommunity.member.repository.MemberRepository;
 import com.kakao.saramaracommunity.support.IntegrationTestSupport;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
@@ -68,7 +69,7 @@ class BoardServiceImplTest extends IntegrationTestSupport {
     }
 
     @Nested
-    @DisplayName("게시글 조회 시")
+    @DisplayNameGeneration(ReplaceUnderscores.class)
     class 게시글_조회_시 {
         private Board SAVED_BOARD;
         @BeforeEach
@@ -99,10 +100,10 @@ class BoardServiceImplTest extends IntegrationTestSupport {
     }
 
     @Nested
-    @DisplayName("게시글 작성 시")
+    @DisplayNameGeneration(ReplaceUnderscores.class)
     class 게시글_작성_시 {
         @Nested
-        @DisplayName("등록된 회원이라면")
+        @DisplayNameGeneration(ReplaceUnderscores.class)
         class 등록된_회원이라면 {
             @Test
             @DisplayName("[Green] 투표 카테고리의 글을 작성할 때 최소 2장 이상의 이미지를 등록해야 한다.")
@@ -178,10 +179,10 @@ class BoardServiceImplTest extends IntegrationTestSupport {
             }
         }
         @Nested
-        @DisplayName("등록되지 않은 회원이라면")
+        @DisplayNameGeneration(ReplaceUnderscores.class)
         class 등록되지_않은_회원이라면 {
             @Test
-            @DisplayName("[Exception] 작성할 수 없다.")
+            @DisplayName("[Red] 작성할 수 없다.")
             void 작성할_수_없다() {
                 // given
                 Member NOT_SAVED_MEMBER = NORMAL_MEMBER_WOOGI.createMember();
@@ -196,7 +197,7 @@ class BoardServiceImplTest extends IntegrationTestSupport {
     }
 
     @Nested
-    @DisplayName("게시글 수정 시")
+    @DisplayNameGeneration(ReplaceUnderscores.class)
     class 게시글_수정_시 {
         private Board SAVED_VOTE_BOARD;
         private Board SAVED_CHOICE_BOARD;
@@ -207,7 +208,7 @@ class BoardServiceImplTest extends IntegrationTestSupport {
             boardRepository.saveAll(List.of(SAVED_VOTE_BOARD, SAVED_CHOICE_BOARD));
         }
         @Nested
-        @DisplayName("등록된 회원이라면")
+        @DisplayNameGeneration(ReplaceUnderscores.class)
         class 등록된_회원이라면 {
             @Test
             @DisplayName("[Green] 본인의 게시글을 수정할 수 있다.")
@@ -224,7 +225,7 @@ class BoardServiceImplTest extends IntegrationTestSupport {
                 assertThat(result.get().getContent()).isEqualTo("update-content");
             }
             @Test
-            @DisplayName("[Exception] 다른 회원의 게시글은 수정할 수 없다.")
+            @DisplayName("[Red] 다른 회원의 게시글은 수정할 수 없다.")
             void 다른_회원의_게시글은_수정할_수_없다() {
                 // given
                 BoardUpdateServiceRequest request = createUpdateRequest(VOTE, MEMBER_SONNY, createImagePaths(4));
@@ -308,10 +309,10 @@ class BoardServiceImplTest extends IntegrationTestSupport {
             }
         }
         @Nested
-        @DisplayName("등록되지 않은 회원이라면")
+        @DisplayNameGeneration(ReplaceUnderscores.class)
         class 등록되지_않은_회원이라면 {
             @Test
-            @DisplayName("[Exception] 수정할 수 없다.")
+            @DisplayName("[Red] 수정할 수 없다.")
             void 수정할_수_없다() {
                 // given
                 Member NOT_SAVED_MEMBER = NORMAL_MEMBER_WOOGI.createMember();
@@ -326,7 +327,7 @@ class BoardServiceImplTest extends IntegrationTestSupport {
     }
 
     @Nested
-    @DisplayName("게시글 삭제 시")
+    @DisplayNameGeneration(ReplaceUnderscores.class)
     class 게시글_삭제_시 {
         private Board SAVED_BOARD;
         @BeforeEach
@@ -349,7 +350,7 @@ class BoardServiceImplTest extends IntegrationTestSupport {
             assertThat(deletedImages).isEmpty();
         }
         @Test
-        @DisplayName("[Exception] 다른 회원의 게시글은 삭제할 수 없다.")
+        @DisplayName("[Red] 다른 회원의 게시글은 삭제할 수 없다.")
         void 다른_회원의_게시글은_삭제할_수_없다() {
             // given
             BoardDeleteServiceRequest request = createDeleteRequest(MEMBER_SONNY.getId());


### PR DESCRIPTION
## 🤔 Motivation
- 누락된 `DisplayNameGenerator.ReplaceUnderscores`를 다시 명시해주기

<br>

## 💡 Key Changes
- 테스트 코드 계층화를 위해 `DisplayNameGenerator.ReplaceUnderscores`를 사용하도록 했으나 이후 게시글 관련 테스트 코드 리뷰 중 `DisplayNameGenerator.ReplaceUnderscores`를 누락했다는 것을 파악하게 되었습니다.
- 이에 DisplayNameGenerator.ReplaceUnderscores를 다시 명시하여 병합하기 위한 PR을 요청드립니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @IToriginal 
