### PR TITLE
[Fix] 투표 조회시 권한 검증 로직 삭제

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/vote/controller/VoteController.java
+++ b/src/main/java/com/kakao/saramaracommunity/vote/controller/VoteController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -53,7 +52,6 @@ public class VoteController {
 
     /**
      * 투표 조회 API
-     * TODO: 사용자 권한 검증을 위한 보안성 강화 관련 개발 예정 (memberId)
      * @param boardId 투표 상태가 저장된 게시글 고유 식별자
      * @return "code", "message", "data" : { "boardId", "totalVotes", "voteCounts"}
      */

--- a/src/main/java/com/kakao/saramaracommunity/vote/service/VoteServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/vote/service/VoteServiceImpl.java
@@ -65,8 +65,6 @@ public class VoteServiceImpl implements VoteService {
     public VotesReadInBoardResponse readVoteInBoard(Long boardId) {
         log.info("[VoteServiceImpl] 요청에 따라 게시글의 투표 조회를 시도합니다.");
 
-        // validateVoter(memberId, boardId); TODO: 사용자 권한 검증을 위한 보안성 강화 관련 개발 예정
-
         List<Object[]> votes = voteRepository.getVotesByBoard(boardId);
         Map<String, Long> voteCounts = getVoteCounts(votes);
         Long totalVotes = calculateTotalVotes(voteCounts);
@@ -134,19 +132,6 @@ public class VoteServiceImpl implements VoteService {
             totalVotes += count;
         }
         return totalVotes;
-    }
-
-    /**
-     * 투표 조회시 사용될 투표자 검증 메소드
-     * TODO: 사용자 권한 검증을 위한 보안성 강화 관련 개발 예정
-     */
-    private void validateVoter(Long memberId, Long boardId) {
-        Optional<Vote> existVote = voteRepository.findByMemberIdAndBoardId(memberId, boardId);
-        if (existVote.isEmpty()) {
-            log.info("[VoteServiceImpl] 투표 상태를 조회할 수 있는 상태가 아닙니다. 투표를 완료해주세요.");
-            throw new MemberBusinessException(UNAUTHORIZED_TO_MEMBER);
-        }
-        log.info("[VoteServiceImpl] 해당 게시글의 투표자 검증이 완료되었습니다.");
     }
 
     private void verifyVoter(Vote vote, Long memberId) {


### PR DESCRIPTION
## 🤔 Motivation
- 투표 조회시 회원, 비회원간의 구분없이 모두에게 투표 상황 통계를 확인할 수 있도록 해당 검증 로직을 제거하였습니다.

<br>

## 💡 Key Changes
- 투표 조회시 `validateVoter` 메서드를 통해 투표자를 검증하여 투표 상황을 조회할 수 있도록 구현되어진 검증 메서드를 제거하였습니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @langoustinee 
- 위의 내용에 대한 피드백 부탁드립니다.
- 추가적으로 개선할 수 있는 부분이나 주의해야 할 사항이 있다면 알려주시면 감사하겠습니다.

close: #148 

