### PR TITLE
[Feat] 투표 도메인 테스트 코드 개발

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/vote/controller/VoteController.java
+++ b/src/main/java/com/kakao/saramaracommunity/vote/controller/VoteController.java
@@ -79,7 +79,7 @@ public class VoteController {
      */
     @PatchMapping("/{voteId}")
     public ResponseEntity<ApiResponse> updateVote(
-            @Valid @PathVariable("voteId") Long voteId,
+            @PathVariable("voteId") Long voteId,
             @Valid @RequestBody VoteUpdateRequest request
     ) {
         voteService.updateVote(voteId, request.toServiceRequest());
@@ -99,7 +99,7 @@ public class VoteController {
      */
     @DeleteMapping("/{voteId}")
     public ResponseEntity<ApiResponse> deleteVote(
-            @Valid @PathVariable("voteId") Long voteId,
+            @PathVariable("voteId") Long voteId,
             @Valid @RequestBody VoteDeleteRequest request
     ) {
         voteService.deleteVote(voteId, request.toServiceRequest());

--- a/src/main/java/com/kakao/saramaracommunity/vote/controller/VoteController.java
+++ b/src/main/java/com/kakao/saramaracommunity/vote/controller/VoteController.java
@@ -8,6 +8,7 @@ import com.kakao.saramaracommunity.vote.dto.business.response.VoteCreateResponse
 import com.kakao.saramaracommunity.vote.dto.business.response.VotesReadInBoardResponse;
 import com.kakao.saramaracommunity.vote.service.VoteService;
 import jakarta.validation.Valid;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
@@ -53,17 +54,18 @@ public class VoteController {
     /**
      * 투표 조회 API
      * @param boardId 투표 상태가 저장된 게시글 고유 식별자
-     * @return "code", "message", "data" : { "boardId", "totalVotes", "voteCounts"}
+     * @return "code", "message", "data" : { "boardId", "isVoted", "totalVotes", "voteCounts"}
      */
     @GetMapping("/{boardId}")
     public ResponseEntity<ApiResponse<VotesReadInBoardResponse>> getBoardVotes(
-            @Valid @PathVariable("boardId") Long boardId
+            @Valid @PathVariable("boardId") Long boardId,
+            Principal principal
     ) {
-        VotesReadInBoardResponse data = voteService.readVoteInBoard(boardId);
+        VotesReadInBoardResponse data = voteService.readVoteInBoard(boardId, principal);
         return ResponseEntity.ok().body(
                 ApiResponse.successResponse(
                         HttpStatus.OK,
-                        "성공적으 게시글의 투표 상태를 조회하였습니다.",
+                        "성공적으로 게시글의 투표 상태를 조회하였습니다.",
                         data
                 )
         );

--- a/src/main/java/com/kakao/saramaracommunity/vote/controller/VoteController.java
+++ b/src/main/java/com/kakao/saramaracommunity/vote/controller/VoteController.java
@@ -58,7 +58,7 @@ public class VoteController {
      */
     @GetMapping("/{boardId}")
     public ResponseEntity<ApiResponse<VotesReadInBoardResponse>> getBoardVotes(
-            @Valid @PathVariable("boardId") Long boardId,
+            @PathVariable("boardId") Long boardId,
             Principal principal
     ) {
         VotesReadInBoardResponse data = voteService.readVoteInBoard(boardId, principal);

--- a/src/main/java/com/kakao/saramaracommunity/vote/dto/business/response/VotesReadInBoardResponse.java
+++ b/src/main/java/com/kakao/saramaracommunity/vote/dto/business/response/VotesReadInBoardResponse.java
@@ -4,16 +4,18 @@ import java.util.Map;
 
 public record VotesReadInBoardResponse(
         Long boardId,
+        Boolean isVoted, // 투표 진행 상태
         Long totalVotes,
         Map<String, Long> voteCounts // 이미지 경로, 투표수
 ) {
 
     public static VotesReadInBoardResponse from(
             Long boardId,
+            Boolean isVoted,
             Long totalVotes,
             Map<String, Long> voteCounts
     ) {
-        return new VotesReadInBoardResponse(boardId, totalVotes, voteCounts);
+        return new VotesReadInBoardResponse(boardId, isVoted, totalVotes, voteCounts);
     }
 
 }

--- a/src/main/java/com/kakao/saramaracommunity/vote/dto/business/response/VotesReadInBoardResponse.java
+++ b/src/main/java/com/kakao/saramaracommunity/vote/dto/business/response/VotesReadInBoardResponse.java
@@ -9,7 +9,7 @@ public record VotesReadInBoardResponse(
         Map<String, Long> voteCounts // 이미지 경로, 투표수
 ) {
 
-    public static VotesReadInBoardResponse from(
+    public static VotesReadInBoardResponse of(
             Long boardId,
             Boolean isVoted,
             Long totalVotes,

--- a/src/main/java/com/kakao/saramaracommunity/vote/exception/VoteErrorCode.java
+++ b/src/main/java/com/kakao/saramaracommunity/vote/exception/VoteErrorCode.java
@@ -1,5 +1,6 @@
 package com.kakao.saramaracommunity.vote.exception;
 
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import com.kakao.saramaracommunity.common.exception.ErrorCode;
@@ -11,7 +12,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum VoteErrorCode implements ErrorCode {
 
-    VOTE_NOT_FOUND(NOT_FOUND, "존재하지 않는 투표입니다.");
+    VOTE_NOT_FOUND(NOT_FOUND, "존재하지 않는 투표입니다."),
+    VOTE_ALREADY_EXISTS(CONFLICT, "이미 투표한 상태입니다.");
 
     private final HttpStatus httpStatus;
 

--- a/src/main/java/com/kakao/saramaracommunity/vote/service/VoteService.java
+++ b/src/main/java/com/kakao/saramaracommunity/vote/service/VoteService.java
@@ -5,12 +5,13 @@ import com.kakao.saramaracommunity.vote.dto.business.request.VoteDeleteServiceRe
 import com.kakao.saramaracommunity.vote.dto.business.request.VoteUpdateServiceRequest;
 import com.kakao.saramaracommunity.vote.dto.business.response.VoteCreateResponse;
 import com.kakao.saramaracommunity.vote.dto.business.response.VotesReadInBoardResponse;
+import java.security.Principal;
 
 public interface VoteService {
 
     VoteCreateResponse createVote(VoteCreateServiceRequest request);
 
-    VotesReadInBoardResponse readVoteInBoard(Long boardId);
+    VotesReadInBoardResponse readVoteInBoard(Long boardId, Principal principal);
 
     void updateVote(Long voteId, VoteUpdateServiceRequest request);
 

--- a/src/main/java/com/kakao/saramaracommunity/vote/service/VoteServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/vote/service/VoteServiceImpl.java
@@ -65,20 +65,21 @@ public class VoteServiceImpl implements VoteService {
     @Override
     @Transactional(readOnly = true)
     public VotesReadInBoardResponse readVoteInBoard(Long boardId, Principal principal) {
+        Board savedBoard = getBoardEntity(boardId);
         log.info("[VoteServiceImpl] 요청에 따라 게시글의 투표 조회를 시도합니다.");
         boolean isVoted = false;
 
         //  Principal 객체가 null이 아니라면, 현재 로그인한 유저가 있는 것이므로, 해당 유저의 정보를 가져온다.
         if (principal != null) {
             Long memberId = getMemberInfo(principal);
-            isVoted = isMemberVoted(memberId, boardId);
+            isVoted = isMemberVoted(memberId, savedBoard.getId());
         }
-        List<Object[]> votes = voteRepository.getVotesByBoard(boardId);
+        List<Object[]> votes = voteRepository.getVotesByBoard(savedBoard.getId());
         Map<String, Long> voteCounts = getVoteCounts(votes);
         Long totalVotes = calculateTotalVotes(voteCounts);
 
         log.info("[VoteServiceImpl] 요청에 따라 게시글 투표 상황을 조회하였습니다.");
-        return new VotesReadInBoardResponse(boardId, isVoted, totalVotes, voteCounts);
+        return VotesReadInBoardResponse.of(savedBoard.getId(), isVoted, totalVotes, voteCounts);
     }
 
     @Override

--- a/src/test/java/com/kakao/saramaracommunity/vote/controller/VoteControllerTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/vote/controller/VoteControllerTest.java
@@ -15,6 +15,8 @@ import com.kakao.saramaracommunity.vote.dto.api.request.VoteCreateRequest;
 import com.kakao.saramaracommunity.vote.dto.api.request.VoteDeleteRequest;
 import com.kakao.saramaracommunity.vote.dto.api.request.VoteUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
@@ -22,7 +24,7 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 class VoteControllerTest extends ControllerTestSupport {
 
     @Nested
-    @DisplayName("신규 투표 시")
+    @DisplayNameGeneration(ReplaceUnderscores.class)
     class 신규_투표_시 {
 
         @Test
@@ -112,7 +114,7 @@ class VoteControllerTest extends ControllerTestSupport {
     }
 
     @Nested
-    @DisplayName("투표 여부 조회 시")
+    @DisplayNameGeneration(ReplaceUnderscores.class)
     class 투표_여부_조회_시 {
 
         @Test
@@ -136,7 +138,7 @@ class VoteControllerTest extends ControllerTestSupport {
     }
 
     @Nested
-    @DisplayName("재투표 시")
+    @DisplayNameGeneration(ReplaceUnderscores.class)
     class 재투표_시 {
 
         private static final Long voteId = 1L;
@@ -214,7 +216,7 @@ class VoteControllerTest extends ControllerTestSupport {
     }
 
     @Nested
-    @DisplayName("투표 취소 시")
+    @DisplayNameGeneration(ReplaceUnderscores.class)
     class 투표_취소_시 {
 
         private static final Long voteId = 1L;

--- a/src/test/java/com/kakao/saramaracommunity/vote/controller/VoteControllerTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/vote/controller/VoteControllerTest.java
@@ -22,12 +22,12 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 class VoteControllerTest extends ControllerTestSupport {
 
     @Nested
-    @DisplayName("게시글에 업로드된 이미지 투표 시")
-    class 게시글에_업로드된_이미지_투표_시 {
+    @DisplayName("신규 투표 시")
+    class 신규_투표_시 {
 
         @Test
-        @DisplayName("이미지 1장을 선택하여 정상적으로 투표할 수 있다.")
-        void 이미지_1장을_선택하여_정상적으로_투표할_수_있다() throws Exception {
+        @DisplayName("정상적으로 투표할 수 있다.")
+        void 정상적으로_투표할_수_있다() throws Exception {
             // given
             VoteCreateRequest request = new VoteCreateRequest(
                     1L, 1L, 1L
@@ -46,15 +46,78 @@ class VoteControllerTest extends ControllerTestSupport {
                     .andExpect(jsonPath("$.message").value("성공적으로 투표를 완료하였습니다."));
         }
 
+        @Test
+        @DisplayName("투표자 정보는 필수로 입력되어야 한다.")
+        void 투표자_정보는_필수로_입력되어야_한다() throws Exception {
+            // given
+            VoteCreateRequest request = new VoteCreateRequest(
+                    null, 1L, 1L
+            );
+
+            // when & then
+            mockMvc.perform(
+                            post("/api/v1/vote")
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                                    .contentType(APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("400"))
+                    .andExpect(jsonPath("$.message").value("[회원 정보는 필수 입니다.]"));
+        }
+
+        @Test
+        @DisplayName("투표할 게시글의 정보는 필수로 입력되어야 한다.")
+        void 투표할_게시글의_정보는_필수로_입력되어야_한다() throws Exception {
+            // given
+            VoteCreateRequest request = new VoteCreateRequest(
+                    1L, null, 1L
+            );
+
+            // when & then
+            mockMvc.perform(
+                            post("/api/v1/vote")
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                                    .contentType(APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("400"))
+                    .andExpect(jsonPath("$.message").value("[게시글 정보는 필수 입니다.]"));
+        }
+
+        @Test
+        @DisplayName("투표할 항목에 대한 정보는 필수로 입력되어야 한다.")
+        void 투표할_항목에_대한_정보는_필수로_입력되어야_한다() throws Exception {
+            // given
+            VoteCreateRequest request = new VoteCreateRequest(
+                    1L, 1L, null
+            );
+
+            // when & then
+            mockMvc.perform(
+                            post("/api/v1/vote")
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                                    .contentType(APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("400"))
+                    .andExpect(jsonPath("$.message").value("[투표할 이미지 정보는 필수 입니다.]"));
+        }
+
     }
 
     @Nested
-    @DisplayName("게시글에 업로드된 이미지 투표 조회 시")
-    class 게시글에_업로드된_이미지_투표_조회_시 {
+    @DisplayName("투표 여부 조회 시")
+    class 투표_여부_조회_시 {
 
         @Test
-        @DisplayName("투표 현황을 조회할 수 있다.")
-        void 투표_현황을_조회할_수_있다() throws Exception {
+        @DisplayName("특정 게시글에 대한 투표 현황을 알 수 있다.")
+        void 특정_게시글에_대한_투표_현황을_알_수_있다() throws Exception {
             // given
             Long boardId = 1L;
 
@@ -67,20 +130,20 @@ class VoteControllerTest extends ControllerTestSupport {
                     .andDo(print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value("200"))
-                    .andExpect(jsonPath("$.message").value("성공적으 게시글의 투표 상태를 조회하였습니다."));
+                    .andExpect(jsonPath("$.message").value("성공적으로 게시글의 투표 상태를 조회하였습니다."));
         }
 
     }
 
     @Nested
-    @DisplayName("게시글에 업로드된 이미지 투표 수정 시")
-    class 게시글에_업로드된_이미지_투표_수정_시 {
+    @DisplayName("재투표 시")
+    class 재투표_시 {
 
         private static final Long voteId = 1L;
 
         @Test
-        @DisplayName("올바른 정보는 정상적으로 수정할 수 있다.")
-        void 올바른_정보는_정상적으로_수정할_수_있다() throws Exception {
+        @DisplayName("정상적으로 다시 투표할 수 있다.")
+        void 정상적으로_다시_투표할_수_있다() throws Exception {
             // given
             VoteUpdateRequest request = new VoteUpdateRequest(
                     1L,
@@ -102,17 +165,63 @@ class VoteControllerTest extends ControllerTestSupport {
                     .andExpect(jsonPath("$.message").value("성공적으로 투표를 수정 하였습니다."));
         }
 
+        @Test
+        @DisplayName("투표자 정보는 필수로 입력되어야 한다.")
+        void 투표자_정보는_필수로_입력되어야_한다() throws Exception {
+            // given
+            VoteUpdateRequest request = new VoteUpdateRequest(
+                    null,
+                    BoardImage.builder()
+                            .path("image-2")
+                            .build()
+            );
+
+            // when & then
+            mockMvc.perform(
+                            patch("/api/v1/vote/" + voteId)
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                                    .contentType(APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(400))
+                    .andExpect(jsonPath("$.message").value("[회원 정보는 필수 입니다.]"));
+        }
+
+        @Test
+        @DisplayName("투표할 항목에 대한 정보는 필수로 입력되어야 한다.")
+        void 투표할_항목에_대한_정보는_필수로_입력되어야_한다() throws Exception {
+            // given
+            VoteUpdateRequest request = new VoteUpdateRequest(
+                    1L,
+                    null
+            );
+
+            // when & then
+            mockMvc.perform(
+                            patch("/api/v1/vote/" + voteId)
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                                    .contentType(APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(400))
+                    .andExpect(jsonPath("$.message").value("[투표할 이미지 정보는 필수 입니다.]"));
+        }
+
     }
 
     @Nested
-    @DisplayName("투표 삭제 시")
-    class 투표_삭제_시 {
+    @DisplayName("투표 취소 시")
+    class 투표_취소_시 {
 
         private static final Long voteId = 1L;
 
         @Test
-        @DisplayName("올바른 정보는 정상적으로 삭제할 수 있다.")
-        void 올바른_정보는_정상적으로_삭제할_수_있다() throws Exception {
+        @DisplayName("정상적으로 취소할 수 있다.")
+        void 정상적으로_취소할_수_있다() throws Exception {
             // given
             VoteDeleteRequest request = new VoteDeleteRequest(1L);
 
@@ -127,7 +236,25 @@ class VoteControllerTest extends ControllerTestSupport {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value(200))
                     .andExpect(jsonPath("$.message").value("성공적으로 투표를 삭제 하였습니다."));
+        }
 
+        @Test
+        @DisplayName("투표자 정보는 필수로 입력되어야 한다.")
+        void 투표자_정보는_필수로_입력되어야_한다() throws Exception {
+            // given
+            VoteDeleteRequest request = new VoteDeleteRequest(null);
+
+            // when & then
+            mockMvc.perform(
+                            delete("/api/v1/vote/" + voteId)
+                                    .content(objectMapper.writeValueAsString(request))
+                                    .with(SecurityMockMvcRequestPostProcessors.csrf())
+                                    .contentType(APPLICATION_JSON)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(400))
+                    .andExpect(jsonPath("$.message").value("[회원 정보는 필수 입니다.]"));
         }
 
     }

--- a/src/test/java/com/kakao/saramaracommunity/vote/controller/VoteControllerTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/vote/controller/VoteControllerTest.java
@@ -52,17 +52,15 @@ class VoteControllerTest extends ControllerTestSupport {
     @DisplayName("게시글에 업로드된 이미지 투표 조회 시")
     class 게시글에_업로드된_이미지_투표_조회_시 {
 
-        @DisplayName("투표를 진행한 회원은 투표를 조회할 수 있다.")
+        @DisplayName("투표 현황을 조회할 수 있다.")
         @Test
-        void 투표를_진행한_회원은_투표를_조회할_수_있다() throws Exception {
+        void 투표_현황을_조회할_수_있다() throws Exception {
             // given
             Long boardId = 1L;
-            Long memberId = 1L;
 
             // when & then
             mockMvc.perform(
                             get("/api/v1/vote/" + boardId)
-                                    .header("memberId", memberId.toString())
                                     .with(SecurityMockMvcRequestPostProcessors.csrf())
                                     .contentType(APPLICATION_JSON)
                     )

--- a/src/test/java/com/kakao/saramaracommunity/vote/controller/VoteControllerTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/vote/controller/VoteControllerTest.java
@@ -25,8 +25,8 @@ class VoteControllerTest extends ControllerTestSupport {
     @DisplayName("게시글에 업로드된 이미지 투표 시")
     class 게시글에_업로드된_이미지_투표_시 {
 
-        @DisplayName("이미지 1장을 선택하여 정상적으로 투표할 수 있다.")
         @Test
+        @DisplayName("이미지 1장을 선택하여 정상적으로 투표할 수 있다.")
         void 이미지_1장을_선택하여_정상적으로_투표할_수_있다() throws Exception {
             // given
             VoteCreateRequest request = new VoteCreateRequest(
@@ -52,8 +52,8 @@ class VoteControllerTest extends ControllerTestSupport {
     @DisplayName("게시글에 업로드된 이미지 투표 조회 시")
     class 게시글에_업로드된_이미지_투표_조회_시 {
 
-        @DisplayName("투표 현황을 조회할 수 있다.")
         @Test
+        @DisplayName("투표 현황을 조회할 수 있다.")
         void 투표_현황을_조회할_수_있다() throws Exception {
             // given
             Long boardId = 1L;
@@ -78,8 +78,8 @@ class VoteControllerTest extends ControllerTestSupport {
 
         private static final Long voteId = 1L;
 
-        @DisplayName("올바른 정보는 정상적으로 수정할 수 있다.")
         @Test
+        @DisplayName("올바른 정보는 정상적으로 수정할 수 있다.")
         void 올바른_정보는_정상적으로_수정할_수_있다() throws Exception {
             // given
             VoteUpdateRequest request = new VoteUpdateRequest(
@@ -110,8 +110,8 @@ class VoteControllerTest extends ControllerTestSupport {
 
         private static final Long voteId = 1L;
 
-        @DisplayName("올바른 정보는 정상적으로 삭제할 수 있다.")
         @Test
+        @DisplayName("올바른 정보는 정상적으로 삭제할 수 있다.")
         void 올바른_정보는_정상적으로_삭제할_수_있다() throws Exception {
             // given
             VoteDeleteRequest request = new VoteDeleteRequest(1L);

--- a/src/test/java/com/kakao/saramaracommunity/vote/entity/VoteTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/vote/entity/VoteTest.java
@@ -1,7 +1,6 @@
 package com.kakao.saramaracommunity.vote.entity;
 
 import static com.kakao.saramaracommunity.fixture.BoardFixture.BOARD_VOTE_WRITER_LANGO;
-import static com.kakao.saramaracommunity.fixture.MemberFixture.NORMAL_MEMBER_LANGO;
 import static com.kakao.saramaracommunity.fixture.MemberFixture.NORMAL_MEMBER_SONNY;
 import static com.kakao.saramaracommunity.fixture.MemberFixture.NORMAL_MEMBER_WOOGI;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +29,7 @@ class VoteTest {
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-        class 회원_정보와_게시글_정보가_주어지는_경우 {
+        class 회원_사용자_정보와_게시글_정보가_주어진다면 {
 
             private Member MEMBER_WOOGI;
             private Board REGISTED_BOARD;
@@ -41,9 +40,9 @@ class VoteTest {
                 REGISTED_BOARD = BOARD_VOTE_WRITER_LANGO.createBoard();
             }
 
-            @DisplayName("한 이미지를 선택하여 올바른 투표 객체를 생성할 수 있다.")
             @Test
-            void 한_이미지를_선택하여_올바른_투표_객체를_생성할_수_있다() {
+            @DisplayName("여러 이미지 중에서 하나의 이미지 항목을 선택하여 투표 객체로 생성할 수 있다.")
+            void 여러_이미지_중에서_하나의_이미지_항목을_선택하여_투표_객체로_생성할_수_있다() {
                 // given
                 BoardImage SELECT_IMAGE = REGISTED_BOARD.getBoardImages().get(0);
 
@@ -65,81 +64,68 @@ class VoteTest {
     class 투표_수정_시 {
 
         private static Board REFISTED_VOTE_BOARD;
-        private static Vote REGISTED_VOTE;
+        private static Vote REGISTED_VOTE; // REFISTED_VOTE_BOARD의 투표
+        private static Member MEMBER_WOOGI; // REGISTED_VOTE의 투표자
+        private static Member MEMBER_SONNY;
+
 
         @BeforeEach
         void setUp() {
-            Member NORMAL_MEMBER = NORMAL_MEMBER_WOOGI.createMember();
-            setField(NORMAL_MEMBER, "id", 1L);
+            MEMBER_WOOGI = NORMAL_MEMBER_WOOGI.createMember();
+            setField(MEMBER_WOOGI, "id", 1L);
+
+            MEMBER_SONNY = NORMAL_MEMBER_SONNY.createMember();
+            setField(MEMBER_SONNY, "id", 2L);
 
             REFISTED_VOTE_BOARD = BOARD_VOTE_WRITER_LANGO.createBoard();
             setField(REFISTED_VOTE_BOARD, "id", 1L);
-            setField(REFISTED_VOTE_BOARD.getMember(), "id", 2L);
+            setField(REFISTED_VOTE_BOARD.getMember(), "id", 3L);
             setField(REFISTED_VOTE_BOARD.getBoardImages().get(0), "id", 1L);
             setField(REFISTED_VOTE_BOARD.getBoardImages().get(1), "id", 2L);
             setField(REFISTED_VOTE_BOARD.getBoardImages().get(2), "id", 3L);
 
             BoardImage SELECT_IMAGE = REFISTED_VOTE_BOARD.getBoardImages().get(0);
-            REGISTED_VOTE = createVote(NORMAL_MEMBER, REFISTED_VOTE_BOARD, SELECT_IMAGE);
+            REGISTED_VOTE = createVote(MEMBER_WOOGI, REFISTED_VOTE_BOARD, SELECT_IMAGE);
 
             setField(REGISTED_VOTE, "id", 1L);
         }
 
-        @Nested
-        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-        class 투표자_정보와_투표의_정보가_일치하는_경우 {
+        @Test
+        @DisplayName("투표자 정보가 일치한다면 투표 객체를 수정할 수 있다.")
+        void 투표자_정보가_일치한다면_투표_객체를_수정할_수_있다() {
+            // given
+            Member REQUEST_MEMBER = MEMBER_WOOGI;
+            BoardImage UPDATE_IMAGE = REFISTED_VOTE_BOARD.getBoardImages().get(1);
 
-            @DisplayName("객체를 수정할 수 있다.")
-            @Test
-            void 객체를_수정할_수_있다() {
-                // given
-                Member REQUEST_MEMBER = REGISTED_VOTE.getMember();
-                BoardImage UPDATE_IMAGE = REFISTED_VOTE_BOARD.getBoardImages().get(1);
+            // when
+            REGISTED_VOTE.changeVote(REQUEST_MEMBER.getId(), UPDATE_IMAGE);
 
-                // when
-                REGISTED_VOTE.changeVote(REQUEST_MEMBER.getId(), UPDATE_IMAGE);
-
-                // then
-                assertThat(REGISTED_VOTE.getBoardImage()).isEqualTo(UPDATE_IMAGE);
-            }
-
+            // then
+            assertThat(REGISTED_VOTE.getBoardImage()).isEqualTo(UPDATE_IMAGE);
         }
 
-        @Nested
-        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-        class 투표자_정보와_투표의_정보가_일치하지_않는_경우 {
+        @Test
+        @DisplayName("투표자 정보가 일치하지 않는다면 투표 객체를 수정할 수는 없다.")
+        void 투표자_정보가_일치하지_않는다면_투표_객체를_수정할_수는_없다() {
+            // given
+            Member REQUEST_MEMBER = MEMBER_SONNY;
+            BoardImage UPDATE_IMAGE = REFISTED_VOTE_BOARD.getBoardImages().get(1);
 
-            private Member MEMBER_SONNY;
-
-            @BeforeEach
-            void setUp() {
-                MEMBER_SONNY = NORMAL_MEMBER_SONNY.createMember();
-                setField(MEMBER_SONNY, "id", 3L);
-            }
-
-            @DisplayName("객체를 수정할 수 없다.")
-            @Test
-            void 객체를_수정할_수_없다() {
-                // given
-                Member REQUEST_MEMBER = MEMBER_SONNY;
-                BoardImage UPDATE_IMAGE = REFISTED_VOTE_BOARD.getBoardImages().get(1);
-
-                // when & then
-                assertThatThrownBy(() -> REGISTED_VOTE.changeVote(REQUEST_MEMBER.getId(), UPDATE_IMAGE))
-                        .isInstanceOf(MemberBusinessException.class)
-                        .hasMessage("권한이 없는 사용자입니다.");
-            }
-
+            // when & then
+            assertThatThrownBy(() -> REGISTED_VOTE.changeVote(REQUEST_MEMBER.getId(), UPDATE_IMAGE))
+                    .isInstanceOf(MemberBusinessException.class)
+                    .hasMessage("권한이 없는 사용자입니다.");
         }
 
-    }
+        private static Vote createVote(
+                Member NORMAL_MEMBER,
+                Board VOTE_BOARD,
+                BoardImage SELECT_IMAGE
+        ) {
 
-    private static Vote createVote(
-            Member NORMAL_MEMBER,
-            Board VOTE_BOARD,
-            BoardImage SELECT_IMAGE
-    ) {
-        return Vote.of(NORMAL_MEMBER, VOTE_BOARD, SELECT_IMAGE);
+            return Vote.of(NORMAL_MEMBER, VOTE_BOARD, SELECT_IMAGE);
+        }
+
     }
 
 }

--- a/src/test/java/com/kakao/saramaracommunity/vote/service/VoteServiceImplTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/vote/service/VoteServiceImplTest.java
@@ -186,8 +186,8 @@ class VoteServiceImplTest extends IntegrationTestSupport {
             }
 
             @Test
-            @DisplayName("[Green] 투표를 진행한 회원이라면 투표 완료 상태를 알 수 있다.")
-            void 투표를_진행한_회원이라면_투표_완료_상태를_알_수_있다() {
+            @DisplayName("[Green] 투표를 진행한 경우 투표 완료 상태를 알 수 있다.")
+            void 투표를_진행한_경우_투표_완료_상태를_알_수_있다() {
                 // given
                 Principal mockPrincipal = new Principal() {
                     @Override
@@ -206,8 +206,8 @@ class VoteServiceImplTest extends IntegrationTestSupport {
             }
 
             @Test
-            @DisplayName("[Green] 투표를 진행하지 않은 회원이라면 투표 미완료 상태를 알 수 있다.")
-            void 투표를_진행하지_않은_회원이라면_투표_미완료_상태를_알_수_있다() {
+            @DisplayName("[Green] 투표를 진행하지 않은 경우 투표 미완료 상태를 알 수 있다.")
+            void 투표를_진행하지_않은_경우_투표_미완료_상태를_알_수_있다() {
                 // given
                 Principal mockPrincipal = new Principal() {
                     @Override


### PR DESCRIPTION
## 🤔 Motivation
- 투표 관련 단위테스트와 통합테스트 DCI 패턴으로 생성/리팩토링하게 되었습니다.
- 투표 조회 API 관련 회원, 비회원 권한은 상관하지 않고 API를 사용할 수 있도록 테스트가 수정되었습니다.
- 투표 조회 API 관련 회원(투표 완료 회원, 투표 미완료 회원 ), 비회원의 투표 상태를 응답하도록 응답 필드를 추가하였습니다.
- 투표 상태를 검증하기 위한 로직을 추가 하였습니다.
- 테스트 작성에 필요한 예외 처리가 추가 되었습니다. 

<br>

## 💡 Key Changes
### 1. Unit Test

<img width="547" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/117193889/6b8eecb0-a3ad-4cf2-ae1e-931ff9d7f488">

시나리오의 변경에 따라 불필요한 분기를 삭제하고 시나리오의 내용을 보다 상세하게 수정하였습니다.

### 2. Integration Test

<img width="547" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/117193889/41a12eb7-5f9d-40f4-85d2-eab8c0ee9c10">

투표 조회 API 관련 이슈를 적용하여 시나리오를 수정하고, 사용자 측면에서 와닿는 시나리오로 개선하였습니다.
슬랙을 활용한 @langoustinee 님과의 시나리오 토의를 통해서 아래의 사유로 비회원에 대한 예외처리는 생성에서 한번만 처리하도록 하였습니다.
> @langoustinee : 예외 케이스가 성립이 안되는 것들이 많아서 억지로 넣을 필요가 없다고 생각이 되요. 
> @IToriginal : 저도 비회원에 대해서는 좀 억지로 넣는 것 같다는 생각을 했는데, 불필요한게 맞을지가 의문이더라구요. 

**노션을 통해 설계된 시나리오 중 수정된 시나리오**
투표를 조회할 경우 (회원, 비회원에 관계 없이 통계를 조회할 수 있으며, 투표 상태 필드를 추가하면서 아래와 같이 시나리오 변경)
- [BEFORE] `[Green] 본인의 투표 여부를 알 수 있다.`
- [AFTER] `[Green] 비회원이라도 투표 현황을 알 수 있다.`
- [AFTER] `[Green] 투표를 진행한 회원이라면 투표 완료 상태를 알 수 있다.`
- [AFTER] `[Green] 투표를 진행하지 않은 회원이라면 투표 미완료 상태를 알 수 있다.`

### 3. Slice Test

<img width="547" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/117193889/9a6bfe9f-9176-4b26-921f-c9a80b3886e6">

슬라이스 테스트 시나리오를 추가하였습니다.

### 4. 투표자 확인 로직 추가
투표 도메인의 조회는 비회원, 회원 구분없이 투표 현황을 조회할 수 있습니다. 하지만 아래의 조건을 검증하여 투표 상태를 응답합니다.
- 비회원, 투표 미완료 회원: `isVoted` 필드 `false` 응답
- 투표 완료 회원: `isVoted` 필드 `true` 응답
해당 시나리오를 구성하기 위해서 `GetMapping`의 투표 조회 API에 `Principal`를 추가 하여, 로그인 된 회원의 정보를 함께 `readVoteInBoard` 메서드에 파라미터로 전달합니다. 

비회원의 경우, 로그인 정보가 없기 때문에 `Controller`에서 `Principal` 객체의 값이 `null`일 경우를 검증을 하지 않도록 구현하고, 
`Service` 에서 파라미터로 전달받은 `Principal` 객체가 `null`이 아니라면, 현재 로그인한 유저가 있는 것이므로, 해당 유저의 정보를 가져와서 `isMemberVoted` 메소드를 통해 투표를 진행한 회원인지를 검증하게 됩니다.

### 5. 예외 처리 구문 추가
한 회원은 한 번의 투표만 가능하기 때문에 게시글(`boardId`)와 회원(`memberId`)을 통해 투표가 이루어진 데이터가 존재하는 경우,
Spring Data JPA를 통해 `Optional` 타입의 `findByMemberIdAndBoardId` 메서드로 투표 객체를 찾고, 
이미 존재하는 데이터가 있다면, HTTP 상태 코드 `409` CONFILICT(리소스 충돌) 예외를 발생시키는 검증 로직을 추가하였습니다.

**추가된 테스트 시나리오**
- Integration Test: `[Red] 중복 투표는 할 수 없다.`

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @langoustinee
- 위의 내용에 대한 피드백 부탁드립니다.
- 추가적으로 개선할 수 있는 부분이나 주의해야 할 사항이 있다면 알려주시면 감사하겠습니다.

#120 
#131 
#144 
close: #142 