### PR TITLE
[Feat] Testcontainers(테스트 컨테이너)를 활용해 통합 테스트 수행하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ dependencies {
 	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.3.1'
 	testImplementation 'io.findify:s3mock_2.12:0.2.4'
 
+	// Testcontainers for Java: JUnit5
+	testImplementation "org.testcontainers:junit-jupiter:1.19.7"
+	testImplementation "org.testcontainers:mariadb:1.19.7"
+
 }
 
 tasks.named('test') {

--- a/src/test/java/com/kakao/saramaracommunity/board/service/BoardServiceImplTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/board/service/BoardServiceImplTest.java
@@ -52,13 +52,6 @@ class BoardServiceImplTest extends IntegrationTestSupport {
     @Autowired
     private BoardService boardService;
 
-    @AfterEach
-    void tearDown() {
-        boardImageRepository.deleteAllInBatch();
-        boardRepository.deleteAllInBatch();
-        memberRepository.deleteAllInBatch();
-    }
-
     private Member MEMBER_LANGO;
     private Member MEMBER_SONNY;
 
@@ -66,6 +59,13 @@ class BoardServiceImplTest extends IntegrationTestSupport {
     void setUp() {
         MEMBER_LANGO = memberRepository.save(NORMAL_MEMBER_LANGO.createMember());
         MEMBER_SONNY = memberRepository.save(NORMAL_MEMBER_SONNY.createMember());
+    }
+
+    @AfterEach
+    void tearDown() {
+        boardImageRepository.deleteAllInBatch();
+        boardRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
     }
 
     @Nested

--- a/src/test/java/com/kakao/saramaracommunity/support/IntegrationTestSupport.java
+++ b/src/test/java/com/kakao/saramaracommunity/support/IntegrationTestSupport.java
@@ -3,10 +3,15 @@ package com.kakao.saramaracommunity.support;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Testcontainers
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class IntegrationTestSupport {
-
+    @Container
+    static MariaDBContainer MARIADB_CONTAINER = new MariaDBContainer("mariadb:10.11");
 }


### PR DESCRIPTION
## 🤔 Motivation
- Testcontainers(테스트 컨테이너) 초기 설정 도입

<br>

## 💡 Key Changes
### 도입 배경
- 기존에는 H2를 지양하여 실제 MariaDB를 사용하고 있었는데, 통합 테스트의 경우 @SpringBootTest를 통해 실제 DB 커넥션을 다루고 있었는데요. 테스트 컨텍스트를 실제 DB로 띄우다보니 DB에 크게 의존하게 된다고 생각되어 전부터 테스트 컨테이너를 사용해볼까 고민하다 이제야 적용해보았습니다. 추후 개발 및 운영환경 구분이 필요할 경우는 브랜치별로 구분하여 적용해도 무방하니 일단 사용해보면 좋을 것 같아요.

### 기본 설정
- 저희 프로젝트는 MariaDB를 사용하기로 결정했었기 때문에 **MariaDB LTS 버전 중 하나인 10.11 이미지**를 통해 테스트할 도커 컨테이너를 실행해요.
- 현재는 `IntegrationTestSupport`라는 통합 테스트를 위한 클래스에 테스트 컨테이너를 사용하도록 개발해두었는데요. 그래서`IntegrationTestSupport` 클래스를 상속받은 실제 테스트 클래스를 수행할 때만 도커 컨테이너를 실행하고 검증하고 종료되어요. 현재 통합테스트를 수행하는 패키지는 AwsS3, bucket, board, comment, vote, member까지 총 6개 패키지로 구성되어 있어 **전체 테스트 수행시 총 6개의 컨테이너가 실행**됩니다.
  - _혹시나 계층구조로 작성된 테스트(@Nested)로 인해 컨테이너 실행 빈도가 다르다면 추가적인 디버깅을 진행하겠습니다!_

### 고도화 계획
- 테스트 컨테이너의 경우 제 임의대로 통합 테스트 클래스별로 실행하도록 두었지만, 추후 컨테이너 실행 빈도를 최초 1번만으로 통합하도록 의사결정이 진행될 수 있습니다. 그렇다면, **하나의 컨테이너 안에서 모든 통합 테스트를 수행할 때 테스트 독립성이 깨질 우려가 있어서 테스트 격리를 위한 DB Cleaner를 고려**해야 할 것으로 생각되어요.

> 테스트 컨테이너와 관련된 자세한 내용은 제가 작성한 블로그의 [글](https://velog.io/@langoustine/%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%BB%A8%ED%85%8C%EC%9D%B4%EB%84%88%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%B4-%ED%86%B5%ED%95%A9%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%88%98%ED%96%89%ED%95%98%EA%B8%B0)을 보시면 좋을 것 같습니다..!

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @byeongJoo05 @IToriginal 

close #152 
