### PR TITLE
[Feat] 애플리케이션 배포 환경 구축을 위한 Docker Compose 추가하기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,6 @@ application-test.yml
 
 # local HTTP Client Test
 *.http
+
+# environment env file ignore
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,24 +4,25 @@
 FROM bellsoft/liberica-openjdk-alpine:17 as builder
 
 # 작업 디렉토리 설정
-WORKDIR /app
+#WORKDIR /app
 
 # 소스코드 및 빌드파일 복사
-COPY . .
+#COPY . .
 
 # 빌드 실행
-RUN ./gradlew clean build
+#RUN ./gradlew clean build --stacktrace
 
 # JAR 파일의 위치에 따른 변수 설정(바로 위 RUN 명령에 맞춰 경로를 설정)
-ARG JAR_FILE=build/libs/*.jar
+ARG JAR_FILE=./build/libs/*.jar
+ADD ${JAR_FILE} app.jar
 
 # 런타임 이미지 생성을 위한 새로운 베이스 이미지 OpenJDK 설정
 ## 첫 번째 스테이지에서 빌드된 JAR 파일만을 복사하여 최종 이미지의 크기를 최소한으로 줄이고,
 ## 불필요한 빌드 파일이나 소스 코드 없이 런타임에 필요한 파일만을 포함하기 위함.
-FROM bellsoft/liberica-openjdk-alpine:17
+#FROM bellsoft/liberica-openjdk-alpine:17
 
 # 이전 스테이지에서 생성된 JAR 파일 복사
-COPY --from=builder /app/${JAR_FILE} app.jar
+#COPY --from=builder /app/${JAR_FILE} app.jar
 
 # 애플리케이션 실행에 사용될 포트 노출
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# 베이스 이미지 OpenJDK 설정
+## 현재 개발환경 수준이기에 경량화 수준이 높은 alpine 이미지로 선정함.
+# FROM openjdk:17-jdk-slim as builder
+FROM bellsoft/liberica-openjdk-alpine:17 as builder
+
+# 작업 디렉토리 설정
+WORKDIR /app
+
+# 소스코드 및 빌드파일 복사
+COPY . .
+
+# 빌드 실행
+RUN ./gradlew clean build
+
+# JAR 파일의 위치에 따른 변수 설정(바로 위 RUN 명령에 맞춰 경로를 설정)
+ARG JAR_FILE=build/libs/*.jar
+
+# 런타임 이미지 생성을 위한 새로운 베이스 이미지 OpenJDK 설정
+## 첫 번째 스테이지에서 빌드된 JAR 파일만을 복사하여 최종 이미지의 크기를 최소한으로 줄이고,
+## 불필요한 빌드 파일이나 소스 코드 없이 런타임에 필요한 파일만을 포함하기 위함.
+FROM bellsoft/liberica-openjdk-alpine:17
+
+# 이전 스테이지에서 생성된 JAR 파일 복사
+COPY --from=builder /app/${JAR_FILE} app.jar
+
+# 애플리케이션 실행에 사용될 포트 노출
+EXPOSE 8080
+
+# JAR 파일 실행
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.2"
+services:
+  database:
+    container_name: mariadb-db
+    image: mariadb
+    # TODO: 추후 볼륨 마운트 필요할 수 있음.
+#    volumes:
+#      - ~/docker/mariadb/etc/mysql/conf.d:/etc/mysql/conf.d:ro
+#      - ~/docker/mariadb/var/lib/mysql:/var/lib/mysql
+#      - ~/docker/mariadb/var/log/maria:/var/log/maria
+    environment:
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_ROOT_HOST=${MYSQL_ROOT_HOST}
+    command: ['--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
+    ports:
+      - 3306:3306
+
+  application:
+    container_name: saramara-backend-api
+    build: .
+    environment:
+      SPRING_DATASOURCE_URL: ${DATASOURCE_URL}
+      SPRING_DATASOURCE_USERNAME: ${MYSQL_ROOT_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+    ports:
+      - 8080:8080
+    depends_on:
+      - database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
-version: "3.2"
+version: "3"
 services:
   database:
-    container_name: mariadb-db
-    image: mariadb
+    container_name: mariadb
+    image: mariadb:10.11
     # TODO: 추후 볼륨 마운트 필요할 수 있음.
 #    volumes:
 #      - ~/docker/mariadb/etc/mysql/conf.d:/etc/mysql/conf.d:ro
@@ -15,15 +15,36 @@ services:
     command: ['--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
     ports:
       - 3306:3306
+    healthcheck:
+      test: [ 'CMD', 'mysqladmin', 'ping', '-h', 'localhost', '-u', 'root', '-p$$MYSQL_ROOT_PASSWORD' ]
+      timeout: 10s
+      retries: 5
 
   application:
     container_name: saramara-backend-api
     build: .
     environment:
+      SPRING_PROFILES_ACTIVE: dev
       SPRING_DATASOURCE_URL: ${DATASOURCE_URL}
       SPRING_DATASOURCE_USERNAME: ${MYSQL_ROOT_USERNAME}
       SPRING_DATASOURCE_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     ports:
       - 8080:8080
     depends_on:
-      - database
+      database:
+        condition: service_healthy
+
+#  storage:
+#    container_name: minio
+#    networks:
+#      - container-network
+#    image: minio/minio
+#    command: server /data --console-address ":9001"
+#    environment:
+#      MINIO_ROOT_USER: ${STORAGE_ADMIN_USERNAME}    # 필요한 경우 수정
+#      MINIO_ROOT_PASSWORD: ${STORAGE_ADMIN_PASSWORD}    # 필요한 경우 수정
+#    restart: always
+#    shm_size: '1gb'  # default는 64MB
+#    ports:
+#      - "9000:9000"    # minio 서비스 포트
+#      - "9001:9001"    # minio 콘솔 포트

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local
+    active: dev
     group:
       local: local
       dev: dev

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: dev
+    active: local
     group:
       local: local
       dev: dev


### PR DESCRIPTION
## 🤔 Motivation
- 개발환경 배포 전 이미지 정상 여부 테스트를 위한 docker-compose 확장

<br>

## 💡 Key Changes

### dockerfile
- OpenJDK로 사용할 베이스 이미지의 경우 `openjdk:17-jdk-slim`와 같은 일반적인 이미지가 아닌 `bellsoft/liberica-openjdk-alpine:17` 이미지를 사용하였습니다. `bellsoft/liberica-openjdk-alpine:17` 이미지는 Alpine Linux를 기반으로 하여, 이미지 크기를 최소화하는 것에 초점을 맞춰 경량화되었기에 테스트 단계에서 보다 빠르고 가볍게 이미지화하는데 도움이 될 것으로 판단하여 해당 이미지를 사용했습니다.

### docker-compose
- Spring Application과 MariaDB를 함께 구동하기 위해 Docker Compose로 설정을 해두었습니다. 
- 애플리케이션은 8080 포트로, MariaDB는 3306포트로 구동됩니다.
- 추후 DB 볼륨 설정이 필요할 경우 volumes 설정을 확장하면 됩니다.

### 로컬 환경 실행 가이드
1. 도커가 로컬 환경에 구비되어 있어야 합니다. 본 프로젝트에서는 Docker Desktop을 이용하기로 결정했기에 Docker Desktop을 설치하시면 됩니다.
2. 프로젝트 최상위 경로에 .env 파일을 만들어 환경변수를 작성합니다. (자세한 환경변수 내용은 노션에 최신화 해두었습니다.)
3. 프로젝트 최상위 경로에서 애플리케이션을 빌드하여 jar 파일을 준비합니다. (_빌드 성공하면 build/lib 디렉토리 하위에 jar파일이 생성되었는지 확인합니다._)
4. 프로젝트 최상위 경로에서 아래 명령을 수행합니다.

```bash
# 첫번째 명령
./gradlew clean build

# 두번째 명령
docker compose up -d
```

5. 약 30초 정도 배포 시간 소요 후, docker ps 명령이나, Docker Desktop UI로 애플리케이션 컨테이너와 MariaDB 컨테이너가 정상적으로 실행되고 있는지 확인합니다.

<img width="1250" alt="image" src="https://github.com/four-uncles/saramara-community-server/assets/59594946/e1c24ec5-aa39-4895-bcd7-fc73abe298ec">

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @byeongJoo05 @IToriginal 

close #157 