### PR TITLE
[Bucket/Feat] 프레젠테이션 계층 및 비즈니스 계층 DTO 변환을 위한 인터페이스 컨벤션 개발

### DIFF
--- a/src/main/java/com/kakao/saramaracommunity/board/controller/BoardController.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/controller/BoardController.java
@@ -1,11 +1,11 @@
 package com.kakao.saramaracommunity.board.controller;
 
-import com.kakao.saramaracommunity.board.dto.api.reqeust.BoardCreateRequest;
-import com.kakao.saramaracommunity.board.dto.api.reqeust.BoardDeleteRequest;
-import com.kakao.saramaracommunity.board.dto.api.reqeust.BoardUpdateRequest;
-import com.kakao.saramaracommunity.board.dto.business.response.BoardCreateResponse;
-import com.kakao.saramaracommunity.board.dto.business.response.BoardGetResponse;
-import com.kakao.saramaracommunity.board.dto.business.response.BoardSearchResponse;
+import com.kakao.saramaracommunity.board.controller.dto.reqeust.BoardCreateRequest;
+import com.kakao.saramaracommunity.board.controller.dto.reqeust.BoardDeleteRequest;
+import com.kakao.saramaracommunity.board.controller.dto.reqeust.BoardUpdateRequest;
+import com.kakao.saramaracommunity.board.controller.dto.response.BoardCreateResponse;
+import com.kakao.saramaracommunity.board.controller.dto.response.BoardGetResponse;
+import com.kakao.saramaracommunity.board.controller.dto.response.BoardSearchResponse;
 import com.kakao.saramaracommunity.board.entity.SortType;
 import com.kakao.saramaracommunity.board.service.BoardService;
 import com.kakao.saramaracommunity.common.response.ApiResponse;
@@ -71,7 +71,7 @@ public class BoardController {
     public ResponseEntity<ApiResponse<BoardCreateResponse>> createBoard(
             @RequestBody @Valid BoardCreateRequest request
     ) {
-        BoardCreateResponse response = boardService.createBoard(request.toServiceReqeust());
+        BoardCreateResponse response = boardService.createBoard(request.toServiceRequest());
         return ResponseEntity.ok().body(
                 ApiResponse.successResponse(
                         OK,

--- a/src/main/java/com/kakao/saramaracommunity/board/controller/dto/reqeust/BoardCreateRequest.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/controller/dto/reqeust/BoardCreateRequest.java
@@ -1,8 +1,9 @@
-package com.kakao.saramaracommunity.board.dto.api.reqeust;
+package com.kakao.saramaracommunity.board.controller.dto.reqeust;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.kakao.saramaracommunity.board.entity.CategoryBoard;
-import com.kakao.saramaracommunity.board.dto.business.reqeust.BoardUpdateServiceRequest;
+import com.kakao.saramaracommunity.board.service.reqeust.BoardCreateServiceRequest;
+import com.kakao.saramaracommunity.common.dto.ConvertDtoByBusinessLayer;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
-public record BoardUpdateRequest(
+public record BoardCreateRequest(
         @NotBlank(message = "게시글의 제목을 입력해주세요.")
         String title,
         @NotBlank(message = "게시글의 내용을 입력해주세요.")
@@ -26,9 +27,11 @@ public record BoardUpdateRequest(
         LocalDateTime deadLine,
         @NotNull(message = "이미지는 최소 1장 이상 등록해야 합니다.")
         List<String> boardImages
-) {
-    public BoardUpdateServiceRequest toServiceRequest() {
-        return BoardUpdateServiceRequest.builder()
+) implements ConvertDtoByBusinessLayer<BoardCreateServiceRequest> {
+
+    @Override
+    public BoardCreateServiceRequest toServiceRequest() {
+        return BoardCreateServiceRequest.builder()
                 .title(title)
                 .content(content)
                 .categoryBoard(categoryBoard)
@@ -37,4 +40,5 @@ public record BoardUpdateRequest(
                 .boardImages(boardImages)
                 .build();
     }
+
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/controller/dto/reqeust/BoardDeleteRequest.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/controller/dto/reqeust/BoardDeleteRequest.java
@@ -1,6 +1,7 @@
-package com.kakao.saramaracommunity.board.dto.api.reqeust;
+package com.kakao.saramaracommunity.board.controller.dto.reqeust;
 
-import com.kakao.saramaracommunity.board.dto.business.reqeust.BoardDeleteServiceRequest;
+import com.kakao.saramaracommunity.board.service.reqeust.BoardDeleteServiceRequest;
+import com.kakao.saramaracommunity.common.dto.ConvertDtoByBusinessLayer;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
@@ -8,10 +9,13 @@ import lombok.Builder;
 public record BoardDeleteRequest(
         @NotNull(message = "존재하지 않는 사용자입니다.")
         Long memberId
-) {
+) implements ConvertDtoByBusinessLayer<BoardDeleteServiceRequest> {
+
+    @Override
     public BoardDeleteServiceRequest toServiceRequest() {
         return BoardDeleteServiceRequest.builder()
                 .memberId(memberId)
                 .build();
     }
+
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/controller/dto/reqeust/BoardUpdateRequest.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/controller/dto/reqeust/BoardUpdateRequest.java
@@ -1,8 +1,9 @@
-package com.kakao.saramaracommunity.board.dto.api.reqeust;
+package com.kakao.saramaracommunity.board.controller.dto.reqeust;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.kakao.saramaracommunity.board.entity.CategoryBoard;
-import com.kakao.saramaracommunity.board.dto.business.reqeust.BoardCreateServiceRequest;
+import com.kakao.saramaracommunity.board.service.reqeust.BoardUpdateServiceRequest;
+import com.kakao.saramaracommunity.common.dto.ConvertDtoByBusinessLayer;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
-public record BoardCreateRequest(
+public record BoardUpdateRequest(
         @NotBlank(message = "게시글의 제목을 입력해주세요.")
         String title,
         @NotBlank(message = "게시글의 내용을 입력해주세요.")
@@ -26,9 +27,11 @@ public record BoardCreateRequest(
         LocalDateTime deadLine,
         @NotNull(message = "이미지는 최소 1장 이상 등록해야 합니다.")
         List<String> boardImages
-) {
-    public BoardCreateServiceRequest toServiceReqeust() {
-        return BoardCreateServiceRequest.builder()
+) implements ConvertDtoByBusinessLayer<BoardUpdateServiceRequest> {
+
+    @Override
+    public BoardUpdateServiceRequest toServiceRequest() {
+        return BoardUpdateServiceRequest.builder()
                 .title(title)
                 .content(content)
                 .categoryBoard(categoryBoard)
@@ -37,4 +40,5 @@ public record BoardCreateRequest(
                 .boardImages(boardImages)
                 .build();
     }
+
 }

--- a/src/main/java/com/kakao/saramaracommunity/board/controller/dto/response/BoardCreateResponse.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/controller/dto/response/BoardCreateResponse.java
@@ -1,4 +1,4 @@
-package com.kakao.saramaracommunity.board.dto.business.response;
+package com.kakao.saramaracommunity.board.controller.dto.response;
 
 import com.kakao.saramaracommunity.board.entity.Board;
 import com.kakao.saramaracommunity.board.entity.BoardImage;

--- a/src/main/java/com/kakao/saramaracommunity/board/controller/dto/response/BoardGetResponse.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/controller/dto/response/BoardGetResponse.java
@@ -1,4 +1,4 @@
-package com.kakao.saramaracommunity.board.dto.business.response;
+package com.kakao.saramaracommunity.board.controller.dto.response;
 
 import com.kakao.saramaracommunity.board.entity.Board;
 import com.kakao.saramaracommunity.board.entity.BoardImage;

--- a/src/main/java/com/kakao/saramaracommunity/board/controller/dto/response/BoardSearchResponse.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/controller/dto/response/BoardSearchResponse.java
@@ -1,4 +1,4 @@
-package com.kakao.saramaracommunity.board.dto.business.response;
+package com.kakao.saramaracommunity.board.controller.dto.response;
 
 import lombok.Builder;
 

--- a/src/main/java/com/kakao/saramaracommunity/board/service/BoardService.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/BoardService.java
@@ -1,11 +1,11 @@
 package com.kakao.saramaracommunity.board.service;
 
-import com.kakao.saramaracommunity.board.dto.business.reqeust.BoardCreateServiceRequest;
-import com.kakao.saramaracommunity.board.dto.business.reqeust.BoardDeleteServiceRequest;
-import com.kakao.saramaracommunity.board.dto.business.reqeust.BoardUpdateServiceRequest;
-import com.kakao.saramaracommunity.board.dto.business.response.BoardCreateResponse;
-import com.kakao.saramaracommunity.board.dto.business.response.BoardGetResponse;
-import com.kakao.saramaracommunity.board.dto.business.response.BoardSearchResponse;
+import com.kakao.saramaracommunity.board.service.reqeust.BoardCreateServiceRequest;
+import com.kakao.saramaracommunity.board.service.reqeust.BoardDeleteServiceRequest;
+import com.kakao.saramaracommunity.board.service.reqeust.BoardUpdateServiceRequest;
+import com.kakao.saramaracommunity.board.controller.dto.response.BoardCreateResponse;
+import com.kakao.saramaracommunity.board.controller.dto.response.BoardGetResponse;
+import com.kakao.saramaracommunity.board.controller.dto.response.BoardSearchResponse;
 import com.kakao.saramaracommunity.board.entity.SortType;
 import org.springframework.data.domain.Pageable;
 

--- a/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/BoardServiceImpl.java
@@ -1,11 +1,11 @@
 package com.kakao.saramaracommunity.board.service;
 
-import com.kakao.saramaracommunity.board.dto.business.reqeust.BoardCreateServiceRequest;
-import com.kakao.saramaracommunity.board.dto.business.reqeust.BoardDeleteServiceRequest;
-import com.kakao.saramaracommunity.board.dto.business.reqeust.BoardUpdateServiceRequest;
-import com.kakao.saramaracommunity.board.dto.business.response.BoardCreateResponse;
-import com.kakao.saramaracommunity.board.dto.business.response.BoardGetResponse;
-import com.kakao.saramaracommunity.board.dto.business.response.BoardSearchResponse;
+import com.kakao.saramaracommunity.board.service.reqeust.BoardCreateServiceRequest;
+import com.kakao.saramaracommunity.board.service.reqeust.BoardDeleteServiceRequest;
+import com.kakao.saramaracommunity.board.service.reqeust.BoardUpdateServiceRequest;
+import com.kakao.saramaracommunity.board.controller.dto.response.BoardCreateResponse;
+import com.kakao.saramaracommunity.board.controller.dto.response.BoardGetResponse;
+import com.kakao.saramaracommunity.board.controller.dto.response.BoardSearchResponse;
 import com.kakao.saramaracommunity.board.entity.Board;
 import com.kakao.saramaracommunity.board.entity.CategoryBoard;
 import com.kakao.saramaracommunity.board.entity.SortType;

--- a/src/main/java/com/kakao/saramaracommunity/board/service/reqeust/BoardCreateServiceRequest.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/reqeust/BoardCreateServiceRequest.java
@@ -1,4 +1,4 @@
-package com.kakao.saramaracommunity.board.dto.business.reqeust;
+package com.kakao.saramaracommunity.board.service.reqeust;
 
 import com.kakao.saramaracommunity.board.entity.Board;
 import com.kakao.saramaracommunity.board.entity.CategoryBoard;
@@ -17,6 +17,7 @@ public record BoardCreateServiceRequest(
         LocalDateTime deadLine,
         List<String> boardImages
 ) {
+
     public Board toEntity(Member member) {
         return Board.builder()
                 .title(title)

--- a/src/main/java/com/kakao/saramaracommunity/board/service/reqeust/BoardDeleteServiceRequest.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/reqeust/BoardDeleteServiceRequest.java
@@ -1,4 +1,4 @@
-package com.kakao.saramaracommunity.board.dto.business.reqeust;
+package com.kakao.saramaracommunity.board.service.reqeust;
 
 import lombok.Builder;
 

--- a/src/main/java/com/kakao/saramaracommunity/board/service/reqeust/BoardUpdateServiceRequest.java
+++ b/src/main/java/com/kakao/saramaracommunity/board/service/reqeust/BoardUpdateServiceRequest.java
@@ -1,4 +1,4 @@
-package com.kakao.saramaracommunity.board.dto.business.reqeust;
+package com.kakao.saramaracommunity.board.service.reqeust;
 
 import com.kakao.saramaracommunity.board.entity.CategoryBoard;
 import lombok.Builder;

--- a/src/main/java/com/kakao/saramaracommunity/bucket/service/BucketServiceImpl.java
+++ b/src/main/java/com/kakao/saramaracommunity/bucket/service/BucketServiceImpl.java
@@ -3,6 +3,7 @@ package com.kakao.saramaracommunity.bucket.service;
 import com.kakao.saramaracommunity.bucket.controller.port.BucketService;
 import com.kakao.saramaracommunity.bucket.controller.response.BucketUploadResponse;
 import com.kakao.saramaracommunity.bucket.exception.BucketBusinessException;
+import com.kakao.saramaracommunity.bucket.service.dto.response.BucketUploadServiceResponse;
 import com.kakao.saramaracommunity.bucket.service.port.ObjectStorageClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -39,7 +40,7 @@ public class BucketServiceImpl implements BucketService {
         }
         List<String> imagePathList = uploadS3BucketWithGetUrls(requestImageFiles);
         log.info("[BucketServiceImpl] AWS S3 버킷에 이미지를 정상적으로 등록했습니다. S3 버킷 등록 이미지 목록: {}", imagePathList);
-        return BucketUploadResponse.of(imagePathList);
+        return BucketUploadServiceResponse.of(imagePathList).toApiResponse();
     }
 
     private boolean checkImageIsEmpty(List<MultipartFile> images) {

--- a/src/main/java/com/kakao/saramaracommunity/bucket/service/dto/response/BucketUploadServiceResponse.java
+++ b/src/main/java/com/kakao/saramaracommunity/bucket/service/dto/response/BucketUploadServiceResponse.java
@@ -1,0 +1,21 @@
+package com.kakao.saramaracommunity.bucket.service.dto.response;
+
+import com.kakao.saramaracommunity.bucket.controller.response.BucketUploadResponse;
+import com.kakao.saramaracommunity.common.dto.ConvertDtoByPresentationLayer;
+
+import java.util.List;
+
+public record BucketUploadServiceResponse(
+        List<String> images
+) implements ConvertDtoByPresentationLayer<BucketUploadResponse> {
+
+    public static BucketUploadServiceResponse of(List<String> images) {
+        return new BucketUploadServiceResponse(images);
+    }
+
+    @Override
+    public BucketUploadResponse toApiResponse() {
+        return BucketUploadResponse.of(images);
+    }
+
+}

--- a/src/main/java/com/kakao/saramaracommunity/common/dto/ConvertDtoByBusinessLayer.java
+++ b/src/main/java/com/kakao/saramaracommunity/common/dto/ConvertDtoByBusinessLayer.java
@@ -1,0 +1,5 @@
+package com.kakao.saramaracommunity.common.dto;
+
+public interface ConvertDtoByBusinessLayer<T> {
+    T toServiceRequest();
+}

--- a/src/main/java/com/kakao/saramaracommunity/common/dto/ConvertDtoByPresentationLayer.java
+++ b/src/main/java/com/kakao/saramaracommunity/common/dto/ConvertDtoByPresentationLayer.java
@@ -1,0 +1,5 @@
+package com.kakao.saramaracommunity.common.dto;
+
+public interface ConvertDtoByPresentationLayer<T> {
+    T toApiResponse();
+}

--- a/src/test/java/com/kakao/saramaracommunity/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/board/controller/BoardControllerTest.java
@@ -1,8 +1,8 @@
 package com.kakao.saramaracommunity.board.controller;
 
-import com.kakao.saramaracommunity.board.dto.api.reqeust.BoardCreateRequest;
-import com.kakao.saramaracommunity.board.dto.api.reqeust.BoardDeleteRequest;
-import com.kakao.saramaracommunity.board.dto.api.reqeust.BoardUpdateRequest;
+import com.kakao.saramaracommunity.board.controller.dto.reqeust.BoardCreateRequest;
+import com.kakao.saramaracommunity.board.controller.dto.reqeust.BoardDeleteRequest;
+import com.kakao.saramaracommunity.board.controller.dto.reqeust.BoardUpdateRequest;
 import com.kakao.saramaracommunity.support.ControllerTestSupport;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;

--- a/src/test/java/com/kakao/saramaracommunity/board/service/BoardServiceImplTest.java
+++ b/src/test/java/com/kakao/saramaracommunity/board/service/BoardServiceImplTest.java
@@ -1,10 +1,10 @@
 package com.kakao.saramaracommunity.board.service;
 
-import com.kakao.saramaracommunity.board.dto.business.reqeust.BoardCreateServiceRequest;
-import com.kakao.saramaracommunity.board.dto.business.reqeust.BoardDeleteServiceRequest;
-import com.kakao.saramaracommunity.board.dto.business.reqeust.BoardUpdateServiceRequest;
-import com.kakao.saramaracommunity.board.dto.business.response.BoardCreateResponse;
-import com.kakao.saramaracommunity.board.dto.business.response.BoardGetResponse;
+import com.kakao.saramaracommunity.board.service.reqeust.BoardCreateServiceRequest;
+import com.kakao.saramaracommunity.board.service.reqeust.BoardDeleteServiceRequest;
+import com.kakao.saramaracommunity.board.service.reqeust.BoardUpdateServiceRequest;
+import com.kakao.saramaracommunity.board.controller.dto.response.BoardCreateResponse;
+import com.kakao.saramaracommunity.board.controller.dto.response.BoardGetResponse;
 import com.kakao.saramaracommunity.board.entity.Board;
 import com.kakao.saramaracommunity.board.entity.BoardImage;
 import com.kakao.saramaracommunity.board.entity.CategoryBoard;


### PR DESCRIPTION
## 🤔 Motivation
- 프레젠테이션 계층 및 비즈니스 계층 DTO 변환을 위한 인터페이스 개발

<br>

## 💡 Key Changes

### 프레젠테이션 계층의 요청 DTO 격리를 강제할 인터페이스 `ConvertDtoByBusinessLayer`
- API 요청을 통해 매핑된 controller 패키지의 DTO를 비즈니스 계층인 service 패키지의 DTO로 변환하여 계층 격리를 이루기 위한 인터페이스를 추가하였습니다.
- controller 패키지의 DTO들은 해당 인터페이스의 toServiceReqeust() 메소드를 구현할 의무가 있고, 해당 함수를 구현하여 service 패키지의 DTO로 변환하여 사용하면 됩니다.

### 비즈니스 계층의 응답 DTO 변환 격리를 강제할 인터페이스 `ConvertDtoByPresentationLayer`
- 비즈니스 로직을 수행한 후 클라이언트에게 적절한 응답을 객체화하여 프레젠테이션 계층의 DTO로 매핑할 때 service 패키지의 DTO들 해당 인터페이스의 toApiResponse() 메소드를 구현합니다.

> 해당 인터페이스들을 프레젠테이션 계층의 요청 DTO와 비즈니스 계층의 응답 DTO에 알맞게 구현하도록 한다면 아키텍처 계층 격리에 대한 컨벤션을 따르기 수월해질 것으로 기대합니다. **해당 PR에서는 bucket 패키지와 board 패키지를 대상으로만 임의로 반영**하였으니 참고 바랍니다.

<br>

## 👨‍👨‍👧‍👦 To Reviewers
- @byeongJoo05 @IToriginal 
